### PR TITLE
Fix service worker asset caching

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,14 +1,12 @@
 
 // Cache name with version
-const CACHE_NAME = 'glee-world-v1';
+const CACHE_NAME = 'glee-world-v2';
 
-// Assets to cache
+// Assets to pre-cache (static files)
 const urlsToCache = [
   '/',
   '/index.html',
   '/manifest.json',
-  '/src/main.tsx',
-  '/src/index.css',
   '/lovable-uploads/8fa96710-a03a-4033-9ee0-032306d74daa.png',
   '/lovable-uploads/b57ced8e-7ed7-405b-8302-41ab726303af.png'
 ];
@@ -26,36 +24,35 @@ self.addEventListener('install', (event) => {
 
 // Cache and return requests
 self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  if (request.method !== 'GET' || !request.url.startsWith(self.location.origin)) {
+    return;
+  }
+
+  // Runtime caching for built JS/CSS and other same-origin assets
   event.respondWith(
-    caches.match(event.request)
-      .then((response) => {
-        // Cache hit - return response
-        if (response) {
+    caches.match(request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+
+      const fetchRequest = request.clone();
+
+      return fetch(fetchRequest).then((response) => {
+        if (!response || response.status !== 200 || response.type !== 'basic') {
           return response;
         }
-        
-        // Clone the request
-        const fetchRequest = event.request.clone();
-        
-        return fetch(fetchRequest).then(
-          (response) => {
-            // Check if valid response
-            if (!response || response.status !== 200 || response.type !== 'basic') {
-              return response;
-            }
-            
-            // Clone the response
-            const responseToCache = response.clone();
-            
-            caches.open(CACHE_NAME)
-              .then((cache) => {
-                cache.put(event.request, responseToCache);
-              });
-              
-            return response;
-          }
-        );
-      })
+
+        const responseToCache = response.clone();
+
+        caches.open(CACHE_NAME).then((cache) => {
+          cache.put(request, responseToCache);
+        });
+
+        return response;
+      });
+    })
   );
 });
 


### PR DESCRIPTION
## Summary
- update service worker cache name
- remove dev asset paths from pre-cache list
- add runtime caching for built assets

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852ddf756548321b475abd8324bb9de