### PR TITLE
Use env vars for Supabase client config

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,16 @@
 import { createClient } from '@supabase/supabase-js';
 
 // Get the Supabase URL and key from environment variables
-const supabaseUrl = 'https://dzzptovqfqausipsgabw.supabase.co';
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR6enB0b3ZxZnFhdXNpcHNnYWJ3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY0MDM1MjksImV4cCI6MjA2MTk3OTUyOX0.7jSsV-y-32C7f23rw6smPPzuQs6HsQeKpySP4ae_C5s';
+const supabaseUrl =
+  import.meta.env.VITE_SUPABASE_URL ??
+  (typeof process !== 'undefined' ? process.env.VITE_SUPABASE_URL : undefined);
+const supabaseAnonKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY ??
+  (typeof process !== 'undefined' ? process.env.VITE_SUPABASE_ANON_KEY : undefined);
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing Supabase configuration. Please define VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.');
+}
 
 // Create a single instance of the Supabase client with proper configuration
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL?: string;
+  readonly VITE_SUPABASE_ANON_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- read Supabase URL and anon key from environment variables
- define environment variables in `vite-env.d.ts`

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ddf1daac832190daf197a0d1df8c