### PR TITLE
Load Supabase creds from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,14 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Environment Variables
+
+Certain features require Supabase credentials. Define these variables in a `.env` file or your deployment environment:
+
+```bash
+SUPABASE_URL=<your-supabase-url>
+SUPABASE_ANON_KEY=<your-supabase-anon-key>
+```
+
+If these variables are missing, the application will log a warning and fall back to the default credentials bundled with the code.

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -1,9 +1,20 @@
 
 import { createClient } from '@supabase/supabase-js';
 
-// Get the Supabase URL and key from environment variables
-const supabaseUrl = 'https://dzzptovqfqausipsgabw.supabase.co';
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR6enB0b3ZxZnFhdXNpcHNnYWJ3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY0MDM1MjksImV4cCI6MjA2MTk3OTUyOX0.7jSsV-y-32C7f23rw6smPPzuQs6HsQeKpySP4ae_C5s';
+// Get the Supabase URL and key from Vite environment variables
+const envUrl = import.meta.env.SUPABASE_URL as string | undefined;
+const envAnonKey = import.meta.env.SUPABASE_ANON_KEY as string | undefined;
+
+if (!envUrl || !envAnonKey) {
+  console.warn(
+    'Missing SUPABASE_URL or SUPABASE_ANON_KEY environment variables. Using fallback credentials.'
+  );
+}
+
+const supabaseUrl = envUrl ?? 'https://dzzptovqfqausipsgabw.supabase.co';
+const supabaseAnonKey =
+  envAnonKey ??
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR6enB0b3ZxZnFhdXNpcHNnYWJ3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY0MDM1MjksImV4cCI6MjA2MTk3OTUyOX0.7jSsV-y-32C7f23rw6smPPzuQs6HsQeKpySP4ae_C5s';
 
 // Create a single instance of the Supabase client with proper configuration
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {


### PR DESCRIPTION
## Summary
- read Supabase credentials via `import.meta.env`
- warn and fall back to bundled values if missing
- document required env variables in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847af37cd148321b66904e7b34e9d01