### PR TITLE
Remove Supabase fallback credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ SUPABASE_URL=<your-supabase-url>
 SUPABASE_ANON_KEY=<your-supabase-anon-key>
 ```
 
-If these variables are missing, the application will log a warning and fall back to the default credentials bundled with the code.
+Both variables are required. The application will fail to start if either one is missing.

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -6,15 +6,13 @@ const envUrl = import.meta.env.SUPABASE_URL as string | undefined;
 const envAnonKey = import.meta.env.SUPABASE_ANON_KEY as string | undefined;
 
 if (!envUrl || !envAnonKey) {
-  console.warn(
-    'Missing SUPABASE_URL or SUPABASE_ANON_KEY environment variables. Using fallback credentials.'
+  throw new Error(
+    'SUPABASE_URL and SUPABASE_ANON_KEY environment variables are required.'
   );
 }
 
-const supabaseUrl = envUrl ?? 'https://dzzptovqfqausipsgabw.supabase.co';
-const supabaseAnonKey =
-  envAnonKey ??
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR6enB0b3ZxZnFhdXNpcHNnYWJ3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY0MDM1MjksImV4cCI6MjA2MTk3OTUyOX0.7jSsV-y-32C7f23rw6smPPzuQs6HsQeKpySP4ae_C5s';
+const supabaseUrl = envUrl;
+const supabaseAnonKey = envAnonKey;
 
 // Create a single instance of the Supabase client with proper configuration
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {


### PR DESCRIPTION
## Summary
- enforce SUPABASE_URL and SUPABASE_ANON_KEY by throwing when missing
- document requirement for these variables in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*
- `npm run build:dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e25edd74832180d5ce8207301e70