### PR TITLE
Add testing setup for hero components

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,5 +25,14 @@ export default tseslint.config(
       ],
       "@typescript-eslint/no-unused-vars": "off",
     },
+  },
+  {
+    files: ["**/__tests__/**/*.{ts,tsx}", "**/*.test.{ts,tsx}"],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+      },
+    },
   }
 );

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fullcalendar/core": "^6.1.17",
@@ -106,6 +107,10 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^15.0.2",
+    "@testing-library/user-event": "^14.5.2",
+    "vitest": "^1.3.1"
   }
 }

--- a/src/__tests__/hero/DynamicHero.test.tsx
+++ b/src/__tests__/hero/DynamicHero.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { DynamicHero } from '@/components/landing/DynamicHero';
+import { HeroSlideContent } from '@/components/landing/hero/HeroSlideContent';
+import { useHeroData } from '@/components/landing/hero/useHeroData';
+import type { HeroSlide, MediaFile } from '@/components/landing/hero/types';
+
+vi.mock('@/components/landing/hero/useHeroData');
+
+const mockedUseHeroData = vi.mocked(useHeroData);
+
+describe('DynamicHero', () => {
+  it('renders HeroDefault when no slides exist', () => {
+    mockedUseHeroData.mockReturnValue({
+      slides: [],
+      mediaFiles: {},
+      currentIndex: 0,
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+
+    render(<DynamicHero />);
+    expect(screen.getByText(/Spelman College Glee Club/i)).toBeInTheDocument();
+  });
+});
+
+describe('HeroSlideContent', () => {
+  it('renders slide content with media', () => {
+    const slide: HeroSlide = {
+      id: '1',
+      title: 'Test Slide',
+      description: 'Hello',
+      button_text: 'Click',
+      button_link: 'https://example.com',
+      media_id: 'media1',
+      media_type: 'image',
+      visible: true,
+      slide_order: 1,
+      text_position: 'center',
+    };
+
+    const mediaFiles: Record<string, MediaFile> = {
+      media1: { id: 'media1', file_url: 'https://example.com/test.jpg', title: 'Media' },
+    };
+
+    render(<HeroSlideContent slide={slide} mediaFiles={mediaFiles} />);
+
+    expect(screen.getByAltText('Test Slide')).toHaveAttribute('src', 'https://example.com/test.jpg');
+    expect(screen.getByText('Test Slide')).toBeInTheDocument();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Click' })).toBeInTheDocument();
+  });
+});
+
+describe('useHeroData', () => {
+  it('cycles current slide index', async () => {
+    const slides: HeroSlide[] = [
+      { id: '1', title: 'A', visible: true, slide_order: 1 },
+      { id: '2', title: 'B', visible: true, slide_order: 2 },
+    ];
+
+    mockedUseHeroData.mockRestore();
+    vi.useFakeTimers();
+
+    const supabaseMock = {
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: slides, error: null }),
+        in: vi.fn().mockResolvedValue({ data: [], error: null }),
+        not: vi.fn().mockReturnThis(),
+      })),
+    } as any;
+
+    vi.mock('@/integrations/supabase/client', () => ({ supabase: supabaseMock }));
+
+    const { result, waitFor } = renderHook(() => useHeroData());
+
+    await waitFor(() => !result.current.isLoading);
+
+    expect(result.current.currentIndex).toBe(0);
+
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+
+    expect(result.current.currentIndex).toBe(1);
+
+    vi.useRealTimers();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,8 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  test: {
+    environment: "jsdom",
+    globals: true,
+  },
 }));


### PR DESCRIPTION
## Summary
- add vitest and React Testing Library setup
- configure ESLint to recognize test files
- enable Vitest settings in `vite.config.ts`
- write unit tests for DynamicHero, HeroSlideContent, and useHeroData

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e7a5a29c83219488e14db48f874c