### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,10 @@ git clone <YOUR_GIT_URL>
 # Step 2: Navigate to the project directory.
 cd <YOUR_PROJECT_NAME>
 
-# Step 3: Install the necessary dependencies.
-npm i
+# Step 3: Run the setup script to install dependencies and create a `.env` file.
+./setup.sh
 
-# Step 4: Create a `.env` file by copying the provided example and fill in
-# your Supabase credentials and API keys.
-cp .env.example .env
-
-# Step 5: Start the development server with auto-reloading and an instant preview.
+# Step 4: Start the development server with auto-reloading and an instant preview.
 npm run dev
 ```
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Setup script for local development
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Ensure npm is installed
+if ! command -v npm >/dev/null 2>&1; then
+  echo "Error: npm is not installed. Please install Node.js and npm." >&2
+  exit 1
+fi
+
+# Install project dependencies
+if [ -f package-lock.json ]; then
+  npm ci
+else
+  npm install
+fi
+
+# Create .env if it does not exist
+if [ -f .env.example ] && [ ! -f .env ]; then
+  cp .env.example .env
+  echo "Created .env from .env.example. Update the file with your values." >&2
+fi
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add a `setup.sh` helper for installing dependencies and creating `.env`
- document the setup script in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852eaa799a083218570f99b361c5f53