### PR TITLE
Fix hero fallback when Supabase missing

### DIFF
--- a/src/components/landing/hero/useHeroData.ts
+++ b/src/components/landing/hero/useHeroData.ts
@@ -24,6 +24,13 @@ export function useHeroData() {
 
   const fetchHeroSlides = async () => {
     try {
+      if (!supabase) {
+        console.warn('useHeroData: Supabase not configured, showing default hero');
+        setSlides([]);
+        setMediaFiles({});
+        return;
+      }
+
       console.log('useHeroData: Fetching hero slides...');
       
       // Fetch hero slides

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -1,27 +1,36 @@
 
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 // Get the Supabase URL and key from Vite environment variables
 const envUrl = import.meta.env.SUPABASE_URL as string | undefined;
 const envAnonKey = import.meta.env.SUPABASE_ANON_KEY as string | undefined;
 
+let supabaseUrl: string | undefined = envUrl;
+let supabaseAnonKey: string | undefined = envAnonKey;
+
 if (!envUrl || !envAnonKey) {
-  throw new Error(
-    'SUPABASE_URL and SUPABASE_ANON_KEY environment variables are required.'
+  // In local/test environments the Supabase credentials may be missing.
+  // Instead of throwing an error (which would break the entire app),
+  // log a warning and export `null`. Components can handle this case by
+  // falling back to default behaviour.
+  console.warn(
+    'Supabase environment variables missing. Features depending on Supabase will be disabled.'
   );
+  supabaseUrl = undefined;
+  supabaseAnonKey = undefined;
 }
 
-const supabaseUrl = envUrl;
-const supabaseAnonKey = envAnonKey;
-
-// Create a single instance of the Supabase client with proper configuration
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: {
-    storage: localStorage,
-    persistSession: true,
-    autoRefreshToken: true,
-  }
-});
+// Create a single instance of the Supabase client if credentials exist
+export const supabase: SupabaseClient | null =
+  supabaseUrl && supabaseAnonKey
+    ? createClient(supabaseUrl, supabaseAnonKey, {
+        auth: {
+          storage: localStorage,
+          persistSession: true,
+          autoRefreshToken: true,
+        }
+      })
+    : null;
 
 // Function to clean up authentication state, useful when switching users
 export const cleanupAuthState = () => {


### PR DESCRIPTION
## Summary
- handle missing Supabase credentials without crashing
- show the default hero when Supabase isn't configured

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fe8058f88321ab761a7b5094c941