### PR TITLE
Reduce header height

### DIFF
--- a/src/components/landing/Header.tsx
+++ b/src/components/landing/Header.tsx
@@ -40,7 +40,7 @@ export function Header() {
   
   return (
     <header className="sticky top-0 z-50 w-full bg-white/95 dark:bg-gray-900/95 backdrop-blur-md shadow-sm border-b border-gray-200 dark:border-gray-700">
-      <div className="flex h-16 items-center justify-between w-full px-6">
+      <div className="flex h-8 items-center justify-between w-full px-6">
         {/* Logo - Always visible */}
         <div className="flex-shrink-0">
           <Link to="/" className="font-bold flex items-center hover:text-primary transition-colors">

--- a/src/styles/mobile-optimizations.css
+++ b/src/styles/mobile-optimizations.css
@@ -198,7 +198,7 @@ body {
     margin: 0 !important;
     border-bottom: 1px solid rgba(0, 0, 0, 0.05) !important;
     padding: 0.5rem !important;
-    min-height: 56px !important;
+    min-height: 28px !important;
   }
   
   .dark header {
@@ -208,7 +208,7 @@ body {
   
   /* Header content compact spacing */
   header .flex {
-    min-height: 40px !important;
+    min-height: 20px !important;
     align-items: center !important;
   }
   


### PR DESCRIPTION
## Summary
- shrink the general site header by 50%
- adjust mobile header styles to match reduced height

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685312b71d148321815af71f3473a593