### PR TITLE
Add SoundCloud pages and routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Certain features require Supabase credentials. Define these variables in a `.env
 ```bash
 SUPABASE_URL=<your-supabase-url>
 SUPABASE_ANON_KEY=<your-supabase-anon-key>
+SOUNDCLOUD_CLIENT_ID=<your-soundcloud-client-id>
+SOUNDCLOUD_CLIENT_SECRET=<your-soundcloud-client-secret>
 ```
 
-Both variables are required. The application will fail to start if either one is missing.
+`SUPABASE_URL` and `SUPABASE_ANON_KEY` are required. If you want to enable the optional SoundCloud integration you must also provide `SOUNDCLOUD_CLIENT_ID` and `SOUNDCLOUD_CLIENT_SECRET`. Without these, SoundCloud authentication will fail.

--- a/src/pages/admin/SoundCloudAdminPage.tsx
+++ b/src/pages/admin/SoundCloudAdminPage.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { AdminV2Layout } from '@/layouts/AdminV2Layout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { SoundCloudAuth } from '@/components/soundcloud/SoundCloudAuth';
+import { SoundCloudLibrary } from '@/components/soundcloud/SoundCloudLibrary';
+import { SoundCloudUrlImport } from '@/components/admin/SoundCloudUrlImport';
+import { Music } from 'lucide-react';
+
+export default function SoundCloudAdminPage() {
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+
+  return (
+    <AdminV2Layout>
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Music className="h-5 w-5" /> SoundCloud Integration
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {accessToken ? (
+              <SoundCloudLibrary accessToken={accessToken} />
+            ) : (
+              <SoundCloudAuth onAuthSuccess={(token) => setAccessToken(token)} />
+            )}
+          </CardContent>
+        </Card>
+
+        {accessToken && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Import from URL</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <SoundCloudUrlImport />
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </AdminV2Layout>
+  );
+}

--- a/src/pages/dashboard/SoundCloudLibraryPage.tsx
+++ b/src/pages/dashboard/SoundCloudLibraryPage.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { PageHeader } from '@/components/ui/page-header';
+import { Music } from 'lucide-react';
+import { SoundCloudAuth } from '@/components/soundcloud/SoundCloudAuth';
+import { SoundCloudLibrary } from '@/components/soundcloud/SoundCloudLibrary';
+
+const SoundCloudLibraryPage = () => {
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [user, setUser] = useState<any>(null);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="SoundCloud Library"
+        description="Browse your SoundCloud playlists and tracks"
+        icon={<Music className="h-6 w-6" />}
+      />
+
+      {accessToken ? (
+        <SoundCloudLibrary accessToken={accessToken} />
+      ) : (
+        <SoundCloudAuth
+          onAuthSuccess={(token, u) => {
+            setAccessToken(token);
+            setUser(u);
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default SoundCloudLibraryPage;

--- a/src/routes/adminRoutes.tsx
+++ b/src/routes/adminRoutes.tsx
@@ -12,6 +12,7 @@ import AdminCalendarPage from '@/pages/admin/AdminCalendarPage';
 import MembersPage from '@/pages/admin/MembersPage';
 import HeroSlidesPage from '@/pages/admin/HeroSlidesPage';
 import MusicAdminPage from '@/pages/admin/MusicAdminPage';
+import SoundCloudAdminPage from '@/pages/admin/SoundCloudAdminPage';
 import AdminStorePage from '@/pages/admin/AdminStorePage';
 import CommunicationsPage from '@/pages/admin/CommunicationsPage';
 import EmailServiceManagementPage from '@/pages/admin/EmailServiceManagementPage';
@@ -63,6 +64,10 @@ export const adminRoutes: RouteObject[] = [
       {
         path: 'music',
         element: <MusicAdminPage />,
+      },
+      {
+        path: 'soundcloud',
+        element: <SoundCloudAdminPage />,
       },
       {
         path: 'videos',

--- a/src/routes/dashboardRoutes.tsx
+++ b/src/routes/dashboardRoutes.tsx
@@ -6,6 +6,7 @@ import AuthRoute from '@/components/auth/AuthRoute';
 // Dashboard Pages
 import MemberDashboardPage from '@/pages/dashboard/MemberDashboardPage';
 import FanDashboardPage from '@/pages/dashboard/FanDashboardPage';
+import SoundCloudLibraryPage from '@/pages/dashboard/SoundCloudLibraryPage';
 
 export const dashboardRoutes: RouteObject[] = [
   {
@@ -21,6 +22,14 @@ export const dashboardRoutes: RouteObject[] = [
     element: (
       <AuthRoute>
         <FanDashboardPage />
+      </AuthRoute>
+    ),
+  },
+  {
+    path: '/dashboard/soundcloud',
+    element: (
+      <AuthRoute>
+        <SoundCloudLibraryPage />
       </AuthRoute>
     ),
   },


### PR DESCRIPTION
## Summary
- expose SoundCloud credentials in README
- add SoundCloudLibraryPage for dashboard
- add SoundCloudAdminPage for admins
- route new pages via dashboardRoutes and adminRoutes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot resolve @eslint/js)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6853636eb0f0832195fac0727b7d4f49