### PR TITLE
Adjust hero and music player height, widen performance cards

### DIFF
--- a/src/components/audio/EnhancedCustomAudioPlayer.tsx
+++ b/src/components/audio/EnhancedCustomAudioPlayer.tsx
@@ -165,7 +165,7 @@ export function EnhancedCustomAudioPlayer({ className = "" }: EnhancedCustomAudi
 
   if (isLoading) {
     return (
-      <Card className={className}>
+      <Card className={`${className} min-h-[50vh] flex items-center justify-center`}>
         <CardContent className="p-6 text-center">
           <p className="text-muted-foreground">Loading music player...</p>
         </CardContent>
@@ -175,7 +175,7 @@ export function EnhancedCustomAudioPlayer({ className = "" }: EnhancedCustomAudi
 
   if (!currentTrack || !activePlaylist) {
     return (
-      <Card className={className}>
+      <Card className={`${className} min-h-[50vh] flex items-center justify-center`}>
         <CardContent className="p-6 text-center">
           <p className="text-muted-foreground">No playlist available</p>
         </CardContent>
@@ -184,7 +184,7 @@ export function EnhancedCustomAudioPlayer({ className = "" }: EnhancedCustomAudi
   }
 
   return (
-    <Card className={`${className} bg-white dark:bg-gray-900 border-2 border-gray-200 dark:border-gray-700 shadow-xl`}>
+    <Card className={`${className} bg-white dark:bg-gray-900 border-2 border-gray-200 dark:border-gray-700 shadow-xl min-h-[50vh] flex flex-col justify-center`}>
       <CardContent className="p-6">
         <audio
           ref={audioRef}

--- a/src/components/landing/hero/HeroSlideContent.tsx
+++ b/src/components/landing/hero/HeroSlideContent.tsx
@@ -42,10 +42,10 @@ export function HeroSlideContent({ slide, mediaFiles }: HeroSlideContentProps) {
     : {};
 
   return (
-    <section 
-      className="hero-section relative w-full min-h-[60vh] sm:min-h-[50vh] md:min-h-[55vh] lg:min-h-[60vh] flex items-center justify-center overflow-hidden"
-      style={backgroundStyle}
-    >
+      <section
+        className="hero-section relative w-full min-h-[50vh] flex items-center justify-center overflow-hidden"
+        style={backgroundStyle}
+      >
       {/* Background overlay */}
       <div className="absolute inset-0 bg-black/40"></div>
       

--- a/src/components/landing/performance/PerformanceSection.tsx
+++ b/src/components/landing/performance/PerformanceSection.tsx
@@ -81,9 +81,9 @@ export function PerformanceSection() {
         <div className="mb-12">
           <div className="flex gap-6 overflow-x-auto pb-4 scrollbar-hide snap-x snap-mandatory touch-pan-x">
             {upcomingPerformances.map((performance) => (
-              <Card 
-                key={performance.id} 
-                className="flex-shrink-0 w-80 md:w-96 overflow-hidden hover:shadow-lg transition-shadow snap-start"
+              <Card
+                key={performance.id}
+                className="flex-shrink-0 w-96 overflow-hidden hover:shadow-lg transition-shadow snap-start"
               >
                 <CardContent className="p-6">
                   <div className="flex items-start justify-between mb-4">


### PR DESCRIPTION
## Summary
- reduce hero section height to 50vh
- match Music Player height to the hero
- widen upcoming performance cards to 24rem

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853655cee98832183e230ace2c6a57b