### PR TITLE
Add sister site links

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Sister Sites
+
+This project links out to several subdomains that offer specialized features:
+
+- [reader.gleeworld.org](https://reader.gleeworld.org) – digital sheet music library
+- [studio.gleeworld.org](https://studio.gleeworld.org) – rehearsal and recording hub
+- [merch.gleeworld.org](https://merch.gleeworld.org) – dedicated merchandise store
+
+Navigation to these sister sites appears in the header and mobile menu.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/2cf8ddd9-7edc-45f1-a4ba-011c3aa74730) and click on Share -> Publish.

--- a/src/components/landing/Header.tsx
+++ b/src/components/landing/Header.tsx
@@ -60,6 +60,15 @@ export function Header() {
           <Link to="/calendar" className="text-sm font-medium text-black dark:text-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
             Events
           </Link>
+          <a href="https://reader.gleeworld.org" className="text-sm font-medium text-black dark:text-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
+            Reader
+          </a>
+          <a href="https://studio.gleeworld.org" className="text-sm font-medium text-black dark:text-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
+            Studio
+          </a>
+          <a href="https://merch.gleeworld.org" className="text-sm font-medium text-black dark:text-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
+            Merch
+          </a>
           <Link to="/store" className="text-sm font-medium text-black dark:text-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
             Store
           </Link>

--- a/src/components/layout/mobile/MobileNavDropdown.tsx
+++ b/src/components/layout/mobile/MobileNavDropdown.tsx
@@ -31,6 +31,9 @@ export function MobileNavDropdown() {
     { label: "Home", href: "/" },
     { label: "About", href: "/about" },
     { label: "Calendar", href: "/calendar" },
+    { label: "Reader", href: "https://reader.gleeworld.org" },
+    { label: "Studio", href: "https://studio.gleeworld.org" },
+    { label: "Merch", href: "https://merch.gleeworld.org" },
     { label: "Store", href: "/store" },
     { label: "Contact", href: "/contact" },
   ];


### PR DESCRIPTION
## Summary
- add navigation links to sister sites in header and mobile nav
- document sister site subdomains in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685365f930e483218aa87439fc2c2aa7