### PR TITLE
Improve recording docs and UI hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,9 @@ SOUNDCLOUD_CLIENT_SECRET=<your-soundcloud-client-secret>
 ```
 
 `SUPABASE_URL` and `SUPABASE_ANON_KEY` are required. If you want to enable the optional SoundCloud integration you must also provide `SOUNDCLOUD_CLIENT_ID` and `SOUNDCLOUD_CLIENT_SECRET`. Without these, SoundCloud authentication will fail.
+
+## Recording Library and Karaoke Studio
+
+This project uses open source audio libraries including **Tone.js**, **WaveSurfer.js**, and **soundfont-player** to power the metronome, pitch pipe, and karaoke studio. Saved recordings are uploaded to the Supabase `audio` bucket so your mixes remain accessible from any device.
+
+See [docs/RECORDING_PROCESS.md](docs/RECORDING_PROCESS.md) for a step-by-step guide on creating and managing recordings.

--- a/docs/RECORDING_PROCESS.md
+++ b/docs/RECORDING_PROCESS.md
@@ -1,0 +1,14 @@
+# Recording Process Guide
+
+This project includes a karaoke studio and recording tools built with open source audio libraries such as **Tone.js** and **WaveSurfer.js**. Recordings are stored in a Supabase Storage bucket named `audio`.
+
+## Steps to record
+
+1. Navigate to `Dashboard -> Recording Library`.
+2. Select the **Karaoke Studio** tab.
+3. Choose a backing track and click **Record**. A short countdown begins.
+4. Sing along with the track. Use the volume sliders to balance vocals and backing.
+5. When finished, press **Stop**. Review the preview and save your mix.
+6. The audio file is uploaded to the `audio` bucket and listed under **My Karaoke Recordings**.
+
+You can download or delete any saved mix from the recordings table.

--- a/src/components/recordings/MixedRecordingsList.tsx
+++ b/src/components/recordings/MixedRecordingsList.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { 
   Table,
   TableBody,
@@ -148,6 +148,9 @@ export function MixedRecordingsList() {
       <Card>
         <CardHeader>
           <CardTitle>My Karaoke Recordings</CardTitle>
+          <CardDescription>
+            Recordings are stored securely in the Supabase "audio" bucket.
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <div className="rounded-md border">


### PR DESCRIPTION
## Summary
- document how to record and save mixes
- show bucket location in Karaoke recording list
- mention audio libraries and docs in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853690a19788321bda0d6e91e082ce4