### PR TITLE
Add product image generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,13 @@ SOUNDCLOUD_CLIENT_SECRET=<your-soundcloud-client-secret>
 This project uses open source audio libraries including **Tone.js**, **WaveSurfer.js**, and **soundfont-player** to power the metronome, pitch pipe, and karaoke studio. Saved recordings are uploaded to the Supabase `audio` bucket so your mixes remain accessible from any device.
 
 See [docs/RECORDING_PROCESS.md](docs/RECORDING_PROCESS.md) for a step-by-step guide on creating and managing recordings.
+
+## Updating Store Product Images
+
+If your store items are missing proper product photos, you can generate new mockups with the helper script:
+
+```bash
+node scripts/updateStoreImages.js
+```
+
+The script connects to your Supabase project using `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` from your `.env` file. It looks for T‑shirt, hoodie, and sweatshirt products, generates new images with the `generate-product-mockup` function, and updates each product's `image_url` field.

--- a/scripts/updateStoreImages.js
+++ b/scripts/updateStoreImages.js
@@ -1,0 +1,68 @@
+const { createClient } = require('@supabase/supabase-js');
+require('dotenv').config();
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceKey) {
+  console.error('Missing Supabase credentials. Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in your environment.');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, serviceKey);
+
+function detectProductType(name) {
+  const lower = name.toLowerCase();
+  if (lower.includes('hoodie')) return 'hoodie';
+  if (lower.includes('sweatshirt')) return 'sweatshirt';
+  if (lower.includes('t-shirt') || lower.includes('tee')) return 't-shirt';
+  return null;
+}
+
+async function updateImages() {
+  const { data: items, error } = await supabase.from('store_items').select('*');
+  if (error) {
+    console.error('Failed to fetch store items:', error);
+    return;
+  }
+
+  for (const item of items) {
+    const productType = detectProductType(item.name);
+    if (!productType) continue;
+
+    if (item.image_url && item.image_url.includes('generated-mockups')) continue;
+
+    console.log(`Generating image for ${item.name}...`);
+    const { data, error: genError } = await supabase.functions.invoke('generate-product-mockup', {
+      body: {
+        productType,
+        designText: 'Glee Club',
+        brandInfo: { brand: 'premium', color: { name: 'Spelman Blue', hex: '#0066CC' } },
+        placement: 'full-front',
+        amazonStyle: true,
+        singleMockup: true
+      }
+    });
+
+    if (genError || !data?.mockupUrl) {
+      console.error(`Failed to generate image for ${item.name}:`, genError || data);
+      continue;
+    }
+
+    const { error: updateError } = await supabase
+      .from('store_items')
+      .update({ image_url: data.mockupUrl })
+      .eq('id', item.id);
+
+    if (updateError) {
+      console.error(`Failed to update ${item.name}:`, updateError);
+    } else {
+      console.log(`Updated ${item.name} image.`);
+    }
+  }
+}
+
+updateImages().then(() => {
+  console.log('Image update complete');
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary
- add `updateStoreImages.js` helper to generate product photos
- document how to regenerate store images in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68536b46d110832181e253910015162d