### PR TITLE
Adjust product grid columns for responsive layout

### DIFF
--- a/src/components/landing/sections/StoreSection.tsx
+++ b/src/components/landing/sections/StoreSection.tsx
@@ -46,8 +46,8 @@ export function StoreSection({ products }: StoreSectionProps) {
         </div>
 
         {/* Products Grid */}
-        {featuredProducts.length > 0 ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+          {featuredProducts.length > 0 ? (
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6 mb-8">
             {featuredProducts.map((product, index) => (
               <Card key={product.id} className="group hover:shadow-xl transition-all duration-500 border-0 shadow-lg bg-white/90 dark:bg-card/90 backdrop-blur-sm overflow-hidden">
                 <CardContent className="p-0">

--- a/src/components/store/EnhancedStorefront.tsx
+++ b/src/components/store/EnhancedStorefront.tsx
@@ -188,7 +188,7 @@ export function EnhancedStorefront() {
               </p>
             </div>
           ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
               {filteredItems.map((item) => (
                 <div key={item.id} onClick={() => handleProductClick(item)} className="cursor-pointer">
                   <ProductCard 


### PR DESCRIPTION
## Summary
- update product grid columns to use 2 columns on mobile and expand up to 5 on large screens
- apply the same responsive layout to the store section on the homepage

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68536b9abbd88321bf8276c093cd735e