### PR TITLE
Adjust container padding on mobile

### DIFF
--- a/src/tailwind.config.ts
+++ b/src/tailwind.config.ts
@@ -11,7 +11,11 @@ module.exports = {
   theme: {
     container: {
       center: true,
-      padding: "2rem",
+      padding: {
+        DEFAULT: "0.5rem",
+        sm: "1rem",
+        lg: "2rem",
+      },
       screens: {
         "2xl": "1400px",
       },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,7 +11,11 @@ module.exports = {
   theme: {
     container: {
       center: true,
-      padding: "2rem",
+      padding: {
+        DEFAULT: "0.5rem",
+        sm: "1rem",
+        lg: "2rem",
+      },
       screens: {
         "2xl": "1400px",
       },


### PR DESCRIPTION
## Summary
- tweak Tailwind container padding so mobile containers use more screen width

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68536c385dc88321876cfb992073666d