### PR TITLE
Adjust hero and container widths

### DIFF
--- a/src/components/landing/FooterLinks.tsx
+++ b/src/components/landing/FooterLinks.tsx
@@ -63,7 +63,7 @@ export function FooterLinks({
 
   return (
     <footer className={`border-t bg-muted/50 ${className}`}>
-      <div className="container mx-auto px-4 py-12">
+      <div className="mx-auto w-full max-w-[1800px] px-6 md:px-8 py-12">
         {/* Main Footer Content */}
         <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
           {/* Logo & Tagline */}

--- a/src/components/landing/HomePageContent.tsx
+++ b/src/components/landing/HomePageContent.tsx
@@ -212,12 +212,12 @@ export function HomePageContent({
           <EnhancedEventsSection events={upcomingEvents} />
           
           {/* SoundCloud Music Section */}
-          <div className="mt-16 max-w-7xl mx-auto bg-gradient-to-br from-blue-500 via-blue-600 to-blue-700 rounded-2xl p-8 md:p-12">
+          <div className="mt-16 mx-auto w-full max-w-[1800px] bg-gradient-to-br from-blue-500 via-blue-600 to-blue-700 rounded-2xl p-8 md:p-12">
             <div className="text-center mb-12">
               <h3 className="text-3xl md:text-4xl font-light text-white mb-4 tracking-tight">
                 Listen to the Glee
               </h3>
-              <p className="text-lg text-blue-100 max-w-2xl mx-auto font-light">
+              <p className="text-lg text-blue-100 max-w-4xl mx-auto font-light">
                 Experience our music collection
               </p>
             </div>
@@ -231,7 +231,7 @@ export function HomePageContent({
             ) : soundCloudEmbeds.length > 0 ? (
               <div className="space-y-8">
                 {/* Swipeable Carousel for Embeds */}
-                <Carousel className="w-full max-w-6xl mx-auto" opts={{ dragFree: true, align: "center" }}>
+                <Carousel className="w-full max-w-[1600px] mx-auto" opts={{ dragFree: true, align: "center" }}>
                   <CarouselContent>
                     {soundCloudEmbeds.map((embed, index) => {
                       const currentPlaylist = soundCloudPlaylists[embed.id];
@@ -397,12 +397,12 @@ export function HomePageContent({
           </div>
 
           {/* YouTube Video Section */}
-          <div className="mt-16 max-w-7xl mx-auto">
+          <div className="mt-16 mx-auto w-full max-w-[1800px]">
             <div className="text-center mb-12">
               <h3 className="text-3xl md:text-4xl font-light text-gray-900 dark:text-white mb-4 tracking-tight">
                 Watch the Glee
               </h3>
-              <p className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto font-light">
+              <p className="text-lg text-gray-600 dark:text-gray-400 max-w-4xl mx-auto font-light">
                 Performance videos and behind-the-scenes content
               </p>
             </div>
@@ -419,7 +419,7 @@ export function HomePageContent({
             <h2 className="text-3xl md:text-4xl lg:text-5xl font-light text-gray-900 dark:text-white mb-8 md:mb-10 tracking-tight">
               Glee Store
             </h2>
-            <p className="text-base md:text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto font-light leading-relaxed">
+            <p className="text-base md:text-lg text-gray-600 dark:text-gray-400 max-w-4xl mx-auto font-light leading-relaxed">
               Show your support with official Spelman Glee Club merchandise
             </p>
           </div>

--- a/src/components/landing/hero/HeroDefault.tsx
+++ b/src/components/landing/hero/HeroDefault.tsx
@@ -11,7 +11,7 @@ export function HeroDefault() {
       </div>
       
       {/* Content */}
-      <div className="relative z-10 text-center text-white container px-4 py-8">
+      <div className="relative z-10 text-center text-white w-full max-w-[1800px] mx-auto px-6 md:px-8 py-6 md:py-8">
         <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-bold mb-3 sm:mb-4 md:mb-6 leading-tight">
           Spelman College Glee Club
         </h1>

--- a/src/components/landing/hero/HeroLoading.tsx
+++ b/src/components/landing/hero/HeroLoading.tsx
@@ -5,7 +5,7 @@ export function HeroLoading() {
   return (
     <section className="hero-section relative w-full min-h-[80vh] sm:min-h-[50vh] md:min-h-[55vh] lg:min-h-[60vh] flex items-center justify-center overflow-hidden bg-gradient-to-br from-primary to-orange-500">
       <div className="absolute inset-0 bg-black/20"></div>
-      <div className="relative z-10 text-center text-white py-4 px-2">
+      <div className="relative z-10 text-center text-white w-full max-w-[1800px] mx-auto py-4 px-4">
         <div className="animate-pulse text-sm sm:text-base">Loading...</div>
       </div>
     </section>

--- a/src/components/landing/hero/HeroSlideContent.tsx
+++ b/src/components/landing/hero/HeroSlideContent.tsx
@@ -55,7 +55,7 @@ export function HeroSlideContent({ slide, mediaFiles }: HeroSlideContentProps) {
       )}
       
       {/* Content */}
-      <div className="relative z-10 text-center text-white container px-4 py-8">
+      <div className="relative z-10 text-center text-white w-full max-w-[1800px] mx-auto px-6 md:px-8 py-6 md:py-8">
         <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-bold mb-3 sm:mb-4 md:mb-6 leading-tight">
           {slide?.title || 'Spelman College Glee Club'}
         </h1>

--- a/src/components/landing/sections/EnhancedEventsSection.tsx
+++ b/src/components/landing/sections/EnhancedEventsSection.tsx
@@ -24,7 +24,7 @@ export function EnhancedEventsSection({
 
   return (
     <section className={`py-16 pt-20 md:pt-24 bg-background ${className}`}>
-      <div className="container mx-auto px-4">
+      <div className="mx-auto w-full max-w-[1800px] px-6 md:px-8">
         <div className="text-center mb-12">
           <h2 className="text-3xl font-bold mb-4">{title}</h2>
         </div>

--- a/src/components/landing/sections/StoreSection.tsx
+++ b/src/components/landing/sections/StoreSection.tsx
@@ -30,7 +30,7 @@ export function StoreSection({ products }: StoreSectionProps) {
         <div className="absolute bottom-20 left-10 w-32 h-32 bg-blue-400/5 rounded-full blur-2xl"></div>
       </div>
 
-      <div className="container mx-auto px-4 relative z-10">
+      <div className="mx-auto w-full max-w-[1800px] px-6 md:px-8 relative z-10">
         {/* Section Header */}
         <div className="text-center mb-8">
           <div className="inline-flex items-center gap-2 bg-white/80 dark:bg-card/80 backdrop-blur-sm px-6 py-3 rounded-full shadow-lg border border-purple-200/50 dark:border-purple-800/50 mb-4">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,7 +17,7 @@ module.exports = {
         lg: "2rem",
       },
       screens: {
-        "2xl": "1400px",
+        "2xl": "1800px",
       },
     },
     extend: {


### PR DESCRIPTION
## Summary
- widen container screens in Tailwind config
- expand hero content width and reduce padding
- widen events and store sections
- allow longer descriptions on the homepage

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854014a45e483218fe2ee687ca92a21