### PR TITLE
Add SoundCloud admin tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ This project uses open source audio libraries including **Tone.js**, **WaveSurfe
 
 See [docs/RECORDING_PROCESS.md](docs/RECORDING_PROCESS.md) for a step-by-step guide on creating and managing recordings.
 
+## SoundCloud Integration Tools
+
+The admin panel now includes a dedicated **SoundCloud** section under content management. After connecting your SoundCloud account via OAuth, you can:
+
+- Browse your personal library directly in the dashboard.
+- Import public tracks or playlists by URL.
+- Manage homepage embeds with the **SoundCloud Embed Manager**.
+- Tweak playback options in **Player Settings**.
+
+These tools rely on the SoundCloud API so be sure to configure `SOUNDCLOUD_CLIENT_ID` and `SOUNDCLOUD_CLIENT_SECRET` in your `.env` file.
+
 ## Updating Store Product Images
 
 If your store items are missing proper product photos, you can generate new mockups with the helper script:

--- a/src/components/admin/AdminTopNavigation.tsx
+++ b/src/components/admin/AdminTopNavigation.tsx
@@ -43,6 +43,7 @@ const allNavigationItems = [
   { to: '/admin/permissions', icon: Shield, label: 'Permissions', section: 'users' },
   { to: '/admin/media-library', icon: Image, label: 'Media Library', section: 'content' },
   { to: '/admin/music', icon: Music, label: 'Music Player', section: 'content' },
+  { to: '/admin/soundcloud', icon: Music, label: 'SoundCloud', section: 'content' },
   { to: '/admin/videos', icon: Video, label: 'Videos', section: 'content' },
   { to: '/admin/hero-slides', icon: Presentation, label: 'Hero Slides', section: 'content' },
   { to: '/admin/news-items', icon: Megaphone, label: 'News Items', section: 'content' },

--- a/src/pages/admin/SoundCloudAdminPage.tsx
+++ b/src/pages/admin/SoundCloudAdminPage.tsx
@@ -5,6 +5,8 @@ import { SoundCloudAuth } from '@/components/soundcloud/SoundCloudAuth';
 import { SoundCloudLibrary } from '@/components/soundcloud/SoundCloudLibrary';
 import { SoundCloudUrlImport } from '@/components/admin/SoundCloudUrlImport';
 import { Music } from 'lucide-react';
+import { SoundCloudEmbedManager } from '@/components/admin/soundcloud/SoundCloudEmbedManager';
+import { SoundCloudPlayerSettings } from '@/components/admin/soundcloud/SoundCloudPlayerSettings';
 
 export default function SoundCloudAdminPage() {
   const [accessToken, setAccessToken] = useState<string | null>(null);
@@ -28,14 +30,34 @@ export default function SoundCloudAdminPage() {
         </Card>
 
         {accessToken && (
-          <Card>
-            <CardHeader>
-              <CardTitle>Import from URL</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <SoundCloudUrlImport />
-            </CardContent>
-          </Card>
+          <>
+            <Card>
+              <CardHeader>
+                <CardTitle>Import from URL</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <SoundCloudUrlImport />
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Homepage Embeds</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <SoundCloudEmbedManager />
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Player Settings</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <SoundCloudPlayerSettings />
+              </CardContent>
+            </Card>
+          </>
         )}
       </div>
     </AdminV2Layout>


### PR DESCRIPTION
## Summary
- add SoundCloud entry to the admin navigation
- expand the SoundCloud admin page to include embed manager and player settings
- document new SoundCloud integration tools in the README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685401cea7a48321b43f20a8b17c209b