### PR TITLE
Adjust events layout width

### DIFF
--- a/src/components/landing/CalendarHero.tsx
+++ b/src/components/landing/CalendarHero.tsx
@@ -48,7 +48,7 @@ export const CalendarHero: React.FC<CalendarHeroProps> = ({
   if (upcomingEvents.length === 0) {
     return (
       <section className="py-12 pt-16 md:pt-20 bg-gradient-to-br from-glee-spelman/5 to-glee-purple/5 mt-2.5 md:mt-0">
-        <div className="container mx-auto px-4">
+        <div className="mx-auto w-full max-w-[1800px] px-4">
           <div className="text-center">
             <h2 className="text-3xl font-bold font-playfair text-gray-900 mb-4">Upcoming Events</h2>
             <p className="text-gray-600">Stay tuned for our next performances!</p>
@@ -60,7 +60,7 @@ export const CalendarHero: React.FC<CalendarHeroProps> = ({
 
   return (
     <section className="py-12 pt-16 md:pt-20 bg-gradient-to-br from-glee-spelman/5 to-glee-purple/5 mt-2.5 md:mt-0">
-      <div className="container mx-auto px-4">
+      <div className="mx-auto w-full max-w-[1800px] px-4">
         <h2 className="text-3xl font-bold font-playfair text-gray-900 mb-8">Upcoming Events</h2>
         
         {/* Mobile: Scrollable cards */}

--- a/src/components/landing/EventScroller.tsx
+++ b/src/components/landing/EventScroller.tsx
@@ -40,7 +40,7 @@ export function EventScroller({
   if (events.length === 0) {
     return (
       <section className={`py-8 md:py-12 ${className}`}>
-        <div className="max-w-full md:max-w-3xl lg:max-w-6xl mx-auto px-4 md:px-6 lg:px-8">
+        <div className="mx-auto w-full max-w-[1800px] px-4 md:px-6 lg:px-8">
           <div className="text-center">
             <h2 className="text-3xl font-playfair font-bold mb-4">{title}</h2>
             <p className="text-muted-foreground">No upcoming events at this time.</p>
@@ -52,7 +52,7 @@ export function EventScroller({
 
   return (
     <section className={`py-8 md:py-12 ${className}`}>
-      <div className="max-w-full md:max-w-3xl lg:max-w-6xl mx-auto px-4 md:px-6 lg:px-8">
+      <div className="mx-auto w-full max-w-[1800px] px-4 md:px-6 lg:px-8">
         <div className="flex items-center justify-between mb-8">
           <h2 className="text-3xl font-playfair font-bold">{title}</h2>
           {showViewAllButton && (

--- a/src/components/landing/UpcomingEventsSection.tsx
+++ b/src/components/landing/UpcomingEventsSection.tsx
@@ -9,7 +9,7 @@ export const UpcomingEventsSection: React.FC = () => {
   if (loading) {
     return (
       <section className="py-12 bg-gradient-to-br from-glee-spelman/5 to-glee-purple/5">
-        <div className="container mx-auto px-4">
+        <div className="mx-auto w-full max-w-[1800px] px-4">
           <div className="text-center">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-glee-spelman mx-auto"></div>
             <p className="mt-4 text-muted-foreground">Loading events...</p>


### PR DESCRIPTION
## Summary
- widen upcoming events sections to match hero width

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854162abef08321a3edb241e2f6d21f