### PR TITLE
Add SoundCloud links in admin panel

### DIFF
--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -48,6 +48,7 @@ const navItems = [
   { to: '/admin/financial', icon: DollarSign, label: 'Financial' },
   { to: '/admin/media-library', icon: Image, label: 'Media Library' },
   { to: '/admin/music', icon: Music, label: 'Music Player' },
+  { to: '/admin/soundcloud', icon: Music, label: 'SoundCloud' },
   { to: '/admin/videos', icon: Video, label: 'Videos' },
   { to: '/admin/hero-slides', icon: Presentation, label: 'Hero Slides' },
   { to: '/admin/news-items', icon: Megaphone, label: 'News Items' },

--- a/src/components/admin/UnifiedAdminModules.tsx
+++ b/src/components/admin/UnifiedAdminModules.tsx
@@ -98,28 +98,37 @@ export function UnifiedAdminModules() {
       path: "/admin/users",
       adminOnly: true
     },
-    {
-      id: "music-player",
-      title: "Music Player",
-      description: "Manage playlists and player settings",
-      icon: <Music className="h-6 w-6" />,
-      color: "bg-orange-500",
-      path: "/admin/music",
-      adminOnly: true
-    },
-    {
-      id: "settings",
-      title: "Site Settings",
-      description: "Configure system settings and preferences",
-      icon: <Settings className="h-6 w-6" />,
-      color: "bg-gray-500",
-      path: "/admin/settings",
-      adminOnly: true,
-      isPriority: true
-    },
-    {
-      id: "store",
-      title: "Store Management",
+  {
+    id: "music-player",
+    title: "Music Player",
+    description: "Manage playlists and player settings",
+    icon: <Music className="h-6 w-6" />,
+    color: "bg-orange-500",
+    path: "/admin/music",
+    adminOnly: true
+  },
+  {
+    id: "settings",
+    title: "Site Settings",
+    description: "Configure system settings and preferences",
+    icon: <Settings className="h-6 w-6" />,
+    color: "bg-gray-500",
+    path: "/admin/settings",
+    adminOnly: true,
+    isPriority: true
+  },
+  {
+    id: 'soundcloud-admin',
+    title: 'SoundCloud Admin',
+    description: 'Manage SoundCloud tracks and embeds',
+    icon: <Music className="h-6 w-6" />,
+    color: 'bg-orange-600',
+    path: '/admin/soundcloud',
+    adminOnly: true
+  },
+  {
+    id: "store",
+    title: "Store Management",
       description: "Manage products and orders",
       icon: <ShoppingBag className="h-6 w-6" />,
       color: "bg-emerald-500",


### PR DESCRIPTION
## Summary
- add SoundCloud link to admin sidebar
- list SoundCloud Admin module in unified modules

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541ba43b5083218207b2d04158b8b8