### PR TITLE
refactor hero media lookup

### DIFF
--- a/src/__tests__/hero/DynamicHero.test.tsx
+++ b/src/__tests__/hero/DynamicHero.test.tsx
@@ -16,7 +16,7 @@ describe('DynamicHero', () => {
   it('renders HeroDefault when no slides exist', () => {
     mockedUseHeroData.mockReturnValue({
       slides: [],
-      mediaFiles: {},
+      mediaFiles: {} as Record<string, MediaFile>,
       currentIndex: 0,
       isLoading: false,
       refetch: vi.fn(),

--- a/src/components/landing/hero/HeroSlideContent.tsx
+++ b/src/components/landing/hero/HeroSlideContent.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Button } from '@/components/ui/button';
+import type { MediaFile } from './types';
 
 interface HeroSlide {
   id: string;
@@ -14,22 +15,15 @@ interface HeroSlide {
   order_index: number;
 }
 
-interface MediaFile {
-  id: string;
-  file_url: string;
-  file_type: string;
-  file_name: string;
-}
-
 interface HeroSlideContentProps {
   slide: HeroSlide;
-  mediaFiles: MediaFile[];
+  mediaFiles: Record<string, MediaFile>;
 }
 
 export function HeroSlideContent({ slide, mediaFiles }: HeroSlideContentProps) {
-  
-  const backgroundMedia = slide?.media_id 
-    ? mediaFiles.find(m => m.id === slide.media_id)
+
+  const backgroundMedia = slide?.media_id
+    ? mediaFiles[slide.media_id]
     : null;
 
   const backgroundStyle = backgroundMedia 


### PR DESCRIPTION
## Summary
- type `mediaFiles` in `HeroSlideContent` as a record
- use direct record lookup instead of `Array.find`
- update hero tests for record-based prop

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685418baf09c83218f1027abb58c8a7d