### PR TITLE
Fix slider autoplay when there are no slides

### DIFF
--- a/src/components/landing/CustomSlideRenderer.tsx
+++ b/src/components/landing/CustomSlideRenderer.tsx
@@ -65,10 +65,12 @@ export function CustomSlideRenderer() {
   }, []);
 
   const goToPrevious = () => {
+    if (currentSlides.length === 0) return;
     setCurrentIndex((prevIndex) => (prevIndex - 1 + currentSlides.length) % currentSlides.length);
   };
 
   const goToNext = () => {
+    if (currentSlides.length === 0) return;
     setCurrentIndex((prevIndex) => (prevIndex + 1) % currentSlides.length);
   };
 
@@ -96,7 +98,7 @@ export function CustomSlideRenderer() {
   };
 
   useEffect(() => {
-    if (!isPad) {
+    if (!isPad && currentSlides.length > 0) {
       const timer = setTimeout(() => {
         setCurrentIndex((prevIndex) => (prevIndex + 1) % currentSlides.length);
       }, 5000);


### PR DESCRIPTION
## Summary
- guard slider autoplay when no slides are available
- avoid NaN index in `CustomSlideRenderer`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint modules)*

------
https://chatgpt.com/codex/tasks/task_e_6854260a99908321ae4fc90aebc6e234