### PR TITLE
Improve theme toggle and header layout

### DIFF
--- a/src/components/layout/ConsolidatedHeader.tsx
+++ b/src/components/layout/ConsolidatedHeader.tsx
@@ -5,6 +5,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Bell, Menu, Search } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
+import { useTheme } from '@/contexts/ThemeContext';
 
 interface ConsolidatedHeaderProps {
   onMenuClick?: () => void;
@@ -13,6 +14,7 @@ interface ConsolidatedHeaderProps {
 
 export function ConsolidatedHeader({ onMenuClick, isMobile = false }: ConsolidatedHeaderProps) {
   const { user, logout, profile } = useAuth();
+  const { theme } = useTheme();
 
   const handleSignOut = async () => {
     try {
@@ -27,8 +29,9 @@ export function ConsolidatedHeader({ onMenuClick, isMobile = false }: Consolidat
   };
 
   return (
-    <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 h-16 flex items-center justify-between px-6 transition-colors duration-200">
-      {/* Menu Button (Mobile Only) */}
+    <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 transition-colors duration-200">
+      <div className={`container mx-auto flex items-center justify-between px-4 ${theme === 'light' && !isMobile ? 'py-4' : 'py-2'}`}>
+        {/* Menu Button (Mobile Only) */}
       {isMobile && onMenuClick && (
         <Button
           variant="ghost"
@@ -88,6 +91,7 @@ export function ConsolidatedHeader({ onMenuClick, isMobile = false }: Consolidat
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+      </div>
       </div>
     </header>
   );

--- a/src/components/ui/floating-theme-toggle.tsx
+++ b/src/components/ui/floating-theme-toggle.tsx
@@ -31,9 +31,9 @@ export function FloatingThemeToggle({
       aria-label={theme === "light" ? "Enable dark mode" : "Enable light mode"}
     >
       {theme === "light" ? (
-        <Moon className="h-[1.2rem] w-[1.2rem]" />
+        <Moon className="h-[1.2rem] w-[1.2rem] text-gray-800 dark:text-white" />
       ) : (
-        <Sun className="h-[1.2rem] w-[1.2rem]" />
+        <Sun className="h-[1.2rem] w-[1.2rem] text-gray-800 dark:text-white" />
       )}
       <span className="sr-only">{theme === "light" ? "Dark" : "Light"} mode</span>
     </Button>

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -8,23 +8,17 @@ export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
 
   return (
-    <Button 
-      variant="ghost" 
-      size="default"
+    <Button
+      variant="ghost"
+      size="icon"
       onClick={toggleTheme}
-      className="h-10 px-4 text-sm font-medium"
+      className="h-10 w-10"
       aria-label={theme === "light" ? "Enable dark mode" : "Enable light mode"}
     >
       {theme === "light" ? (
-        <>
-          <Sun className="h-4 w-4 mr-2 text-royal-600 transition-all" />
-          <span className="text-black dark:text-white">Light</span>
-        </>
+        <Moon className="h-5 w-5 text-gray-800 dark:text-white" />
       ) : (
-        <>
-          <Moon className="h-4 w-4 mr-2 text-powder-400 transition-all" />
-          <span className="text-black dark:text-white">Dark</span>
-        </>
+        <Sun className="h-5 w-5 text-gray-800 dark:text-white" />
       )}
       <span className="sr-only">{theme === "light" ? "Dark" : "Light"} mode</span>
     </Button>


### PR DESCRIPTION
## Summary
- remove text labels from theme toggle
- adjust icon colors for both light and dark backgrounds
- keep floating toggle icon responsive to theme
- make header width consistent with page containers
- add padding for light desktop theme

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685426774534832194d3e84ddfabc3be