### PR TITLE
Darken admin headers

### DIFF
--- a/src/components/admin/AdminAnalyticsChart.tsx
+++ b/src/components/admin/AdminAnalyticsChart.tsx
@@ -32,7 +32,7 @@ export function AdminAnalyticsChart({ isMobile = false }: AdminAnalyticsChartPro
   return (
     <Card className="border-0 shadow-sm bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 transition-colors duration-200">
       <CardHeader className="pb-4">
-        <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
+        <CardTitle className="flex items-center gap-2 text-navy-900 dark:text-gray-100">
           <BarChart3 className="h-5 w-5 text-orange-500" />
           Analytics Overview
         </CardTitle>

--- a/src/components/admin/AdminDashboardContent.tsx
+++ b/src/components/admin/AdminDashboardContent.tsx
@@ -49,7 +49,7 @@ export function AdminDashboardContent() {
     <div className="w-full max-w-none px-4 sm:px-6 lg:px-8 py-6 space-y-8">
       {/* Welcome Section */}
       <div className="mb-8 flex items-center justify-between">
-        <h1 className="text-4xl font-bold text-gray-900 dark:text-white font-playfair">
+        <h1 className="text-4xl font-bold text-navy-900 dark:text-white font-playfair">
           Welcome back, {profile?.first_name || 'Admin'}! 👋
         </h1>
         <Badge variant="outline" className="px-3 py-1 text-xs">
@@ -69,13 +69,13 @@ export function AdminDashboardContent() {
           return (
             <Card key={index} className="hover:shadow-md transition-shadow">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1 px-2 pt-2">
-                <CardTitle className="text-xs font-medium text-gray-900 dark:text-white">
+                <CardTitle className="text-xs font-medium text-navy-900 dark:text-white">
                   {stat.title}
                 </CardTitle>
                 <Icon className={`h-4 w-4 ${stat.color}`} />
               </CardHeader>
               <CardContent className="pt-0 pb-2 px-2">
-                <div className="text-lg font-bold text-gray-900 dark:text-white">{stat.value}</div>
+                <div className="text-lg font-bold text-navy-900 dark:text-white">{stat.value}</div>
                 <p className="text-xs text-gray-600 dark:text-gray-300 mt-0.5">
                   {stat.change}
                 </p>

--- a/src/components/admin/AdminRecentActivity.tsx
+++ b/src/components/admin/AdminRecentActivity.tsx
@@ -33,7 +33,7 @@ export function AdminRecentActivity({ isMobile = false }: AdminRecentActivityPro
     return (
       <Card className="border-0 shadow-sm bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 transition-colors duration-200">
         <CardHeader className="pb-4">
-          <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
+          <CardTitle className="flex items-center gap-2 text-navy-900 dark:text-gray-100">
             <Activity className="h-5 w-5 text-orange-500" />
             Recent Activity
           </CardTitle>
@@ -62,7 +62,7 @@ export function AdminRecentActivity({ isMobile = false }: AdminRecentActivityPro
     return (
       <Card className="border-0 shadow-sm bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 transition-colors duration-200">
         <CardHeader className="pb-4">
-          <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
+          <CardTitle className="flex items-center gap-2 text-navy-900 dark:text-gray-100">
             <Activity className="h-5 w-5 text-orange-500" />
             Recent Activity
           </CardTitle>
@@ -78,7 +78,7 @@ export function AdminRecentActivity({ isMobile = false }: AdminRecentActivityPro
     return (
       <Card className="border-0 shadow-sm bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 transition-colors duration-200">
         <CardHeader className="pb-4">
-          <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
+          <CardTitle className="flex items-center gap-2 text-navy-900 dark:text-gray-100">
             <Activity className="h-5 w-5 text-orange-500" />
             Recent Activity
           </CardTitle>
@@ -93,7 +93,7 @@ export function AdminRecentActivity({ isMobile = false }: AdminRecentActivityPro
   return (
     <Card className="border-0 shadow-sm bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 transition-colors duration-200">
       <CardHeader className="pb-4">
-        <CardTitle className="flex items-center gap-2 text-gray-900 dark:text-gray-100">
+        <CardTitle className="flex items-center gap-2 text-navy-900 dark:text-gray-100">
           <Activity className="h-5 w-5 text-orange-500" />
           Recent Activity
         </CardTitle>
@@ -113,7 +113,7 @@ export function AdminRecentActivity({ isMobile = false }: AdminRecentActivityPro
                 
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center justify-between mb-1">
-                    <h4 className="font-medium text-gray-900 dark:text-gray-100 group-hover:text-orange-600 dark:group-hover:text-orange-400 transition-colors duration-200">
+                    <h4 className="font-medium text-navy-900 dark:text-gray-100 group-hover:text-orange-600 dark:group-hover:text-orange-400 transition-colors duration-200">
                       {activity.title}
                     </h4>
                     <div className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -85,7 +85,7 @@ export const AdminSidebar: React.FC = () => {
             <span className="text-white font-bold text-sm">G</span>
           </div>
           <div>
-            <h2 className="text-lg font-bold text-foreground">Admin Panel</h2>
+            <h2 className="text-lg font-bold text-navy-900">Admin Panel</h2>
             <p className="text-xs text-muted-foreground">GleeWorld</p>
           </div>
         </div>

--- a/src/components/admin/AdminStatsCards.tsx
+++ b/src/components/admin/AdminStatsCards.tsx
@@ -169,7 +169,7 @@ export function AdminStatsCards({ isMobile = false }: AdminStatsCardsProps) {
               </div>
               
               <div>
-                <p className="text-lg font-bold text-gray-900 dark:text-gray-100">
+                <p className="text-lg font-bold text-navy-900 dark:text-gray-100">
                   {stat.value}
                 </p>
                 <p className="text-xs text-gray-600 dark:text-gray-400">

--- a/src/components/admin/AdminTopBar.tsx
+++ b/src/components/admin/AdminTopBar.tsx
@@ -162,7 +162,7 @@ export function AdminTopBar({ onMenuClick, isMobile = false }: AdminTopBarProps)
       {isMobile && (
         <div className="px-6 sm:px-8 py-6 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
           <div className="flex items-center justify-between">
-            <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+            <h1 className="text-xl font-semibold text-navy-900 dark:text-white">
               Admin Panel
             </h1>
             

--- a/src/components/admin/AdminTopNavigation.tsx
+++ b/src/components/admin/AdminTopNavigation.tsx
@@ -111,7 +111,7 @@ export const AdminTopNavigation: React.FC = () => {
             <span className="text-white font-bold text-sm">G</span>
           </div>
           <div>
-            <h2 className="text-lg font-bold text-foreground">Admin Panel</h2>
+            <h2 className="text-lg font-bold text-navy-900">Admin Panel</h2>
           </div>
         </div>
 

--- a/src/components/admin/EnhancedMemberManagement.tsx
+++ b/src/components/admin/EnhancedMemberManagement.tsx
@@ -167,7 +167,7 @@ export function EnhancedMemberManagement() {
       {/* Header */}
       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+          <h1 className="text-3xl font-bold text-navy-900 dark:text-white">
             Member Management & Communications
           </h1>
           <p className="text-lg text-gray-600 dark:text-gray-400">

--- a/src/components/admin/MemberManagement.tsx
+++ b/src/components/admin/MemberManagement.tsx
@@ -156,7 +156,7 @@ export function MemberManagement() {
       {/* Header */}
       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+          <h1 className="text-3xl font-bold text-navy-900 dark:text-white">
             Member Management
           </h1>
           <p className="text-lg text-gray-600 dark:text-gray-400">

--- a/src/components/admin/MembersPageSimple.tsx
+++ b/src/components/admin/MembersPageSimple.tsx
@@ -35,7 +35,7 @@ export default function MembersPageSimple() {
             ← Back to Members
           </Button>
           <div>
-            <h1 className="text-2xl font-bold">Bulk Upload Members</h1>
+            <h1 className="text-2xl font-bold text-navy-900">Bulk Upload Members</h1>
             <p className="text-muted-foreground">Import multiple members from a CSV file</p>
           </div>
         </div>
@@ -51,7 +51,7 @@ export default function MembersPageSimple() {
     <div className="container mx-auto px-4 py-8">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold">Members</h1>
+          <h1 className="text-2xl font-bold text-navy-900">Members</h1>
           <p className="text-muted-foreground">Manage Glee Club members</p>
         </div>
         

--- a/src/components/admin/MobileAdminDashboard.tsx
+++ b/src/components/admin/MobileAdminDashboard.tsx
@@ -77,7 +77,7 @@ export function MobileAdminDashboard() {
     <div className="w-full max-w-full p-2 space-y-3 overflow-x-hidden">
       {/* Header */}
       <div className="w-full">
-        <h1 className="text-xl font-bold text-foreground mb-1">
+        <h1 className="text-xl font-bold text-navy-900 mb-1">
           Admin Dashboard
         </h1>
         <p className="text-xs text-muted-foreground">
@@ -128,7 +128,7 @@ export function MobileAdminDashboard() {
 
       {/* Quick Actions */}
       <div className="w-full">
-        <h2 className="text-sm font-semibold text-foreground mb-2">
+        <h2 className="text-sm font-semibold text-navy-900 mb-2">
           Quick Actions
         </h2>
         <div className="grid grid-cols-2 gap-2 w-full">
@@ -142,7 +142,7 @@ export function MobileAdminDashboard() {
                 <div className={`w-8 h-8 ${action.color} rounded-lg flex items-center justify-center text-white mx-auto mb-1`}>
                   <action.icon className="h-4 w-4" />
                 </div>
-                <p className="text-xs font-medium text-foreground mb-0.5">
+                <p className="text-xs font-medium text-navy-900 mb-0.5">
                   {action.title}
                 </p>
                 <p className="text-xs text-muted-foreground">

--- a/src/components/admin/PermissionManagement.tsx
+++ b/src/components/admin/PermissionManagement.tsx
@@ -187,7 +187,7 @@ export function PermissionManagement() {
     <div className="space-y-6">
       <div className="flex items-center gap-2">
         <Shield className="w-6 h-6 text-blue-500" />
-        <h2 className="text-2xl font-bold">Permission Management</h2>
+        <h2 className="text-2xl font-bold text-navy-900">Permission Management</h2>
       </div>
 
       <Tabs defaultValue="features" className="space-y-4">

--- a/src/components/admin/UnifiedAdminModules.tsx
+++ b/src/components/admin/UnifiedAdminModules.tsx
@@ -165,7 +165,7 @@ export function UnifiedAdminModules() {
     <div className="w-full">
       <Card className="w-full">
         <CardHeader className="pb-3">
-          <CardTitle className="flex items-center justify-between text-lg font-bold">
+          <CardTitle className="flex items-center justify-between text-lg font-bold text-navy-900 dark:text-white">
             Admin Modules
             <Badge variant="secondary" className="text-xs font-medium">{sortedModules.length} available</Badge>
           </CardTitle>
@@ -183,7 +183,7 @@ export function UnifiedAdminModules() {
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center justify-between">
-                    <span className="text-sm font-semibold text-foreground group-hover:text-glee-spelman transition-colors duration-200 truncate">
+                    <span className="text-sm font-semibold text-navy-900 group-hover:text-glee-spelman transition-colors duration-200 truncate">
                       {module.title}
                     </span>
                   </div>

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -120,7 +120,7 @@ export default function UserManagement() {
         <div className="bg-white dark:bg-gray-800 border-b px-2 py-2">
           <div className="flex items-center justify-between mb-2">
             <div>
-              <h1 className="text-lg font-semibold text-gray-900 dark:text-white">User Management</h1>
+              <h1 className="text-lg font-semibold text-navy-900 dark:text-white">User Management</h1>
               <p className="text-xs text-gray-600 dark:text-gray-400">Manage Glee Club members ({users.length} total)</p>
             </div>
             
@@ -162,7 +162,7 @@ export default function UserManagement() {
               placeholder="Search users..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="pl-10 w-full h-8 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              className="pl-10 w-full h-8 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 text-sm text-navy-900 dark:text-gray-100 placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             />
           </div>
         </div>
@@ -180,7 +180,7 @@ export default function UserManagement() {
             {filteredUsers.length === 0 ? (
               <div className="text-center py-8 px-4">
                 <Users className="h-12 w-12 text-gray-400 mx-auto mb-3" />
-                <h3 className="font-medium text-gray-900 dark:text-white mb-1">No Members Found</h3>
+                <h3 className="font-medium text-navy-900 dark:text-white mb-1">No Members Found</h3>
                 <p className="text-sm text-gray-600 dark:text-gray-400">
                   {users.length === 0 
                     ? 'No members added yet.' 
@@ -202,7 +202,7 @@ export default function UserManagement() {
                       
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center space-x-1 mb-1">
-                          <h3 className="font-medium text-sm text-gray-900 dark:text-white truncate">
+                          <h3 className="font-medium text-sm text-navy-900 dark:text-white truncate">
                             {user.first_name} {user.last_name}
                           </h3>
                           {user.is_super_admin && (
@@ -266,7 +266,7 @@ export default function UserManagement() {
         {/* Desktop Header */}
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold">User Management</h1>
+            <h1 className="text-2xl font-bold text-navy-900">User Management</h1>
             <p className="text-muted-foreground">Manage Glee Club members ({users.length} total)</p>
           </div>
           <div className="flex gap-2">
@@ -437,7 +437,7 @@ export default function UserManagement() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-white dark:bg-gray-800 rounded-lg p-4 max-w-md w-full mx-4">
             <div className="flex justify-between items-center mb-3">
-              <h2 className="text-lg font-semibold">Import Users from CSV</h2>
+              <h2 className="text-lg font-semibold text-navy-900">Import Users from CSV</h2>
               <Button variant="ghost" onClick={() => setShowImportDialog(false)}>
                 ×
               </Button>

--- a/src/components/admin/UserManagementMobile.tsx
+++ b/src/components/admin/UserManagementMobile.tsx
@@ -75,7 +75,7 @@ export function UserManagementMobile({
       {/* Header */}
       <div className="p-4 border-b bg-white dark:bg-gray-800 sticky top-0 z-10">
         <div className="flex items-center justify-between mb-4">
-          <h1 className="text-xl font-bold">User Management</h1>
+          <h1 className="text-xl font-bold text-navy-900">User Management</h1>
           <Button onClick={onAddUser} size="sm">
             <UserPlus className="h-4 w-4 mr-2" />
             Add User

--- a/src/components/admin/UserManagementSimplified.tsx
+++ b/src/components/admin/UserManagementSimplified.tsx
@@ -147,7 +147,7 @@ export default function UserManagementSimplified() {
   return (
     <div className="container mx-auto p-6">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold">User Management</h1>
+        <h1 className="text-2xl font-bold text-navy-900">User Management</h1>
         <Button onClick={() => setIsInviteDialogOpen(true)}>
           <UserPlus className="mr-2 h-4 w-4" />
           Invite User

--- a/src/components/admin/YouTubeVideoAdmin.tsx
+++ b/src/components/admin/YouTubeVideoAdmin.tsx
@@ -300,7 +300,7 @@ export function YouTubeVideoAdmin() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold">YouTube Content</h2>
+        <h2 className="text-2xl font-bold text-navy-900">YouTube Content</h2>
         <Button onClick={() => setShowAddForm(true)}>
           <Plus className="h-4 w-4 mr-2" />
           Add Content


### PR DESCRIPTION
## Summary
- make members page headings navy
- tweak user management headings across views
- adjust permission and video admin headers

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685426fe965c8321b8419a4a8853dbf1