### PR TITLE
Update admin page heading colors

### DIFF
--- a/src/pages/admin/AdminCalendarPage.tsx
+++ b/src/pages/admin/AdminCalendarPage.tsx
@@ -112,7 +112,7 @@ export default function AdminCalendarPage() {
             <CalendarDays className="h-8 w-8 text-glee-spelman" />
           </div>
           <div>
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+            <h1 className="text-3xl font-bold text-navy-900 dark:text-white mb-2">
               Event Calendar Management
             </h1>
             <p className="text-lg text-gray-600 dark:text-gray-400 mb-3">

--- a/src/pages/admin/AdminDashboardV2.tsx
+++ b/src/pages/admin/AdminDashboardV2.tsx
@@ -69,7 +69,7 @@ export default function AdminDashboardV2() {
       <div className="space-y-6">
         {/* Welcome Header */}
         <div className="border-b pb-6">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+          <h1 className="text-3xl font-bold text-navy-900 dark:text-white">
             Admin Dashboard
           </h1>
           <p className="text-gray-600 dark:text-gray-300 mt-2">

--- a/src/pages/admin/AdminMainPage.tsx
+++ b/src/pages/admin/AdminMainPage.tsx
@@ -22,7 +22,7 @@ export default function AdminMainPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl md:text-3xl font-bold">Admin Dashboard</h1>
+        <h1 className="text-2xl md:text-3xl font-bold text-navy-900 dark:text-white">Admin Dashboard</h1>
         <p className="text-muted-foreground">
           Manage your Glee Club administration
         </p>

--- a/src/pages/admin/AdminMediaLibraryPage.tsx
+++ b/src/pages/admin/AdminMediaLibraryPage.tsx
@@ -35,7 +35,7 @@ const AdminMediaLibraryPage = () => {
               <FileImage className="h-8 w-8 sm:h-10 sm:w-10 text-royal-600" />
             </div>
             <div className="min-w-0">
-              <h1 className="text-xl sm:text-2xl lg:text-headline font-bold text-gray-900 dark:text-white mb-2">
+              <h1 className="text-xl sm:text-2xl lg:text-headline font-bold text-navy-900 dark:text-white mb-2">
                 Media Library Management
               </h1>
               <p className="text-sm sm:text-body text-gray-600 dark:text-gray-300 mb-4">

--- a/src/pages/admin/AdminStorePage.tsx
+++ b/src/pages/admin/AdminStorePage.tsx
@@ -51,7 +51,7 @@ export default function AdminStorePage() {
       <div className="space-y-6">
         {/* Header */}
         <div className="border-b pb-6">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+          <h1 className="text-3xl font-bold text-navy-900 dark:text-white">
             Store Management
           </h1>
           <p className="text-gray-600 dark:text-gray-300 mt-2">

--- a/src/pages/admin/AdminVideosPage.tsx
+++ b/src/pages/admin/AdminVideosPage.tsx
@@ -41,7 +41,7 @@ export default function AdminVideosPage() {
     <div className="w-full max-w-none px-4 sm:px-6 lg:px-8 py-6 space-y-8">
       {/* Welcome Section */}
       <div className="mb-8 flex items-center justify-between">
-        <h1 className="text-4xl font-bold text-gray-900 dark:text-white font-playfair">
+        <h1 className="text-4xl font-bold text-navy-900 dark:text-white font-playfair">
           Video Management
         </h1>
         <Badge variant="outline" className="px-3 py-1 text-xs">

--- a/src/pages/admin/AnalyticsPage.tsx
+++ b/src/pages/admin/AnalyticsPage.tsx
@@ -40,7 +40,7 @@ const AnalyticsPage = () => {
     <div className="w-full max-w-none px-4 sm:px-6 lg:px-8 py-6 space-y-8">
       {/* Welcome Section */}
       <div className="mb-8 flex items-center justify-between">
-        <h1 className="text-4xl font-bold text-gray-900 dark:text-white font-playfair">
+        <h1 className="text-4xl font-bold text-navy-900 dark:text-white font-playfair">
           Analytics Dashboard
         </h1>
         <Badge variant="outline" className="px-3 py-1 text-xs">

--- a/src/pages/admin/CalendarV2Page.tsx
+++ b/src/pages/admin/CalendarV2Page.tsx
@@ -340,7 +340,7 @@ export default function CalendarV2Page() {
         {/* Header */}
         <div className="flex justify-between items-start">
           <div>
-            <h1 className="text-3xl font-bold">Calendar & Events</h1>
+            <h1 className="text-3xl font-bold text-navy-900 dark:text-white">Calendar & Events</h1>
             <p className="text-muted-foreground">Manage rehearsals, performances, and activities</p>
           </div>
           <div className="flex gap-2">

--- a/src/pages/admin/EnhancedCalendarPage.tsx
+++ b/src/pages/admin/EnhancedCalendarPage.tsx
@@ -214,7 +214,7 @@ export default function EnhancedCalendarPage() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-3xl font-bold">Calendar & Events</h1>
+          <h1 className="text-3xl font-bold text-navy-900 dark:text-white">Calendar & Events</h1>
           <p className="text-muted-foreground">Manage choir events and schedules</p>
         </div>
         <Button onClick={() => openEditDialog()}>

--- a/src/pages/admin/FinancialPage.tsx
+++ b/src/pages/admin/FinancialPage.tsx
@@ -41,7 +41,7 @@ const FinancialPage: React.FC = () => {
     <div className="w-full max-w-none px-4 sm:px-6 lg:px-8 py-6 space-y-8">
       {/* Welcome Section */}
       <div className="mb-8 flex items-center justify-between">
-        <h1 className="text-4xl font-bold text-gray-900 dark:text-white font-playfair">
+        <h1 className="text-4xl font-bold text-navy-900 dark:text-white font-playfair">
           Financial Management
         </h1>
         <Badge variant="outline" className="px-3 py-1 text-xs">

--- a/src/pages/admin/HeroSlidesPage.tsx
+++ b/src/pages/admin/HeroSlidesPage.tsx
@@ -356,7 +356,7 @@ export default function HeroSlidesPage() {
       <AdminTopNavigation />
       <div className="p-6 space-y-4">
         <div className="flex justify-between items-center">
-          <h1 className="text-2xl font-bold">Hero Slides Management</h1>
+          <h1 className="text-2xl font-bold text-navy-900 dark:text-white">Hero Slides Management</h1>
           <Button onClick={handleCreateNew} variant="spelman">
             <Plus className="h-4 w-4 mr-2" />
             Add New Slide

--- a/src/pages/admin/MemberDashboardAdmin.tsx
+++ b/src/pages/admin/MemberDashboardAdmin.tsx
@@ -168,7 +168,7 @@ export default function MemberDashboardAdmin() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-3xl font-bold">Member Dashboard</h1>
+          <h1 className="text-3xl font-bold text-navy-900 dark:text-white">Member Dashboard</h1>
           <p className="text-muted-foreground">Manage choir member profiles and information</p>
         </div>
       </div>

--- a/src/pages/admin/MembersPage.tsx
+++ b/src/pages/admin/MembersPage.tsx
@@ -41,7 +41,7 @@ export default function MembersPage() {
     <div className="w-full max-w-none px-4 sm:px-6 lg:px-8 py-6 space-y-8">
       {/* Welcome Section */}
       <div className="mb-8 flex items-center justify-between">
-        <h1 className="text-4xl font-bold text-gray-900 dark:text-white font-playfair">
+        <h1 className="text-4xl font-bold text-navy-900 dark:text-white font-playfair">
           Members Directory
         </h1>
         <Badge variant="outline" className="px-3 py-1 text-xs">

--- a/src/pages/admin/MembersV2Page.tsx
+++ b/src/pages/admin/MembersV2Page.tsx
@@ -247,7 +247,7 @@ export default function MembersV2Page() {
         {/* Header */}
         <div className="flex justify-between items-start">
           <div>
-            <h1 className="text-3xl font-bold">Member Management</h1>
+            <h1 className="text-3xl font-bold text-navy-900 dark:text-white">Member Management</h1>
             <p className="text-muted-foreground">Manage member profiles, roles, and assignments</p>
           </div>
           <Button onClick={openCreateDialog}>

--- a/src/pages/admin/MusicAdminPage.tsx
+++ b/src/pages/admin/MusicAdminPage.tsx
@@ -41,7 +41,7 @@ export default function MusicAdminPage() {
     <div className="w-full max-w-none px-4 sm:px-6 lg:px-8 py-6 space-y-8">
       {/* Welcome Section */}
       <div className="mb-8 flex items-center justify-between">
-        <h1 className="text-4xl font-bold text-gray-900 dark:text-white font-playfair">
+        <h1 className="text-4xl font-bold text-navy-900 dark:text-white font-playfair">
           Music Administration
         </h1>
         <Badge variant="outline" className="px-3 py-1 text-xs">

--- a/src/pages/admin/MusicStudioPage.tsx
+++ b/src/pages/admin/MusicStudioPage.tsx
@@ -10,7 +10,7 @@ export default function MusicStudioPage() {
     <AdminV2Layout>
       <div className="space-y-6">
         <div className="border-b pb-6">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+          <h1 className="text-3xl font-bold text-navy-900 dark:text-white">
             Music Studio
           </h1>
           <p className="text-gray-600 dark:text-gray-300 mt-2">

--- a/src/pages/admin/SheetMusicLibraryPage.tsx
+++ b/src/pages/admin/SheetMusicLibraryPage.tsx
@@ -243,7 +243,7 @@ export default function SheetMusicLibraryPage() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-3xl font-bold">Sheet Music Library</h1>
+          <h1 className="text-3xl font-bold text-navy-900 dark:text-white">Sheet Music Library</h1>
           <p className="text-muted-foreground">Manage and organize choir sheet music</p>
         </div>
         <Button onClick={() => setUploadDialogOpen(true)}>

--- a/src/pages/admin/SheetMusicV2Page.tsx
+++ b/src/pages/admin/SheetMusicV2Page.tsx
@@ -257,7 +257,7 @@ export default function SheetMusicV2Page() {
         {/* Header */}
         <div className="flex justify-between items-start">
           <div>
-            <h1 className="text-3xl font-bold">Sheet Music Library</h1>
+            <h1 className="text-3xl font-bold text-navy-900 dark:text-white">Sheet Music Library</h1>
             <p className="text-muted-foreground">Organize and manage choir sheet music collection</p>
           </div>
           <Button onClick={() => setIsUploadDialogOpen(true)}>

--- a/src/pages/admin/SiteImagesPage.tsx
+++ b/src/pages/admin/SiteImagesPage.tsx
@@ -148,7 +148,7 @@ export default function SiteImagesPage() {
   return (
     <div className="container mx-auto p-6">
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-2xl font-bold">Site Images Management</h1>
+        <h1 className="text-2xl font-bold text-navy-900 dark:text-white">Site Images Management</h1>
         <Button onClick={() => setIsUploadDialogOpen(true)}>
           <Upload className="mr-2 h-4 w-4" />
           Upload Image

--- a/src/pages/admin/StoreV2Page.tsx
+++ b/src/pages/admin/StoreV2Page.tsx
@@ -18,7 +18,7 @@ export default function StoreV2Page() {
       <div className="space-y-6">
         {/* Header */}
         <div className="border-b pb-6">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+          <h1 className="text-3xl font-bold text-navy-900 dark:text-white">
             Store & Merch Manager
           </h1>
           <p className="text-gray-600 dark:text-gray-300 mt-2">

--- a/src/pages/admin/UserManagementPage.tsx
+++ b/src/pages/admin/UserManagementPage.tsx
@@ -43,7 +43,7 @@ const UserManagementPage: React.FC = () => {
     <div className="w-full max-w-none px-4 sm:px-6 lg:px-8 py-6 space-y-8">
       {/* Welcome Section */}
       <div className="mb-8 flex items-center justify-between">
-        <h1 className="text-4xl font-bold text-gray-900 dark:text-white font-playfair">
+        <h1 className="text-4xl font-bold text-navy-900 dark:text-white font-playfair">
           User Management
         </h1>
         <Badge variant="outline" className="px-3 py-1 text-xs">


### PR DESCRIPTION
## Summary
- use navy text for admin page headings

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685429056c08832190dd002465dcb74a