### PR TITLE
Improve financial screen readability

### DIFF
--- a/src/components/financial/BudgetTracker.tsx
+++ b/src/components/financial/BudgetTracker.tsx
@@ -54,7 +54,7 @@ export const BudgetTracker: React.FC = () => {
         <CardContent className="p-6">
           <div className="text-center">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-glee-spelman mx-auto mb-4"></div>
-            <p className="text-muted-foreground">Loading budget data...</p>
+            <p className="text-gray-700 dark:text-gray-300">Loading budget data...</p>
           </div>
         </CardContent>
       </Card>
@@ -76,7 +76,7 @@ export const BudgetTracker: React.FC = () => {
         <CardContent>
           {currentYearBudgets.length === 0 ? (
             <div className="text-center py-8">
-              <p className="text-muted-foreground mb-4">
+              <p className="text-gray-700 dark:text-gray-300 mb-4">
                 No budgets have been created for the current academic year.
               </p>
               <Button onClick={() => setShowAddDialog(true)}>
@@ -98,7 +98,7 @@ export const BudgetTracker: React.FC = () => {
                         <h3 className="font-semibold">{budget.category}</h3>
                         {getStatusBadge(spentPercentage)}
                       </div>
-                      <div className="text-sm text-muted-foreground">
+                      <div className="text-sm text-gray-700 dark:text-gray-300">
                         {formatCurrency(spent)} of {formatCurrency(budget.budgeted_amount)}
                       </div>
                     </div>
@@ -109,7 +109,7 @@ export const BudgetTracker: React.FC = () => {
                     />
                     
                     <div className="flex justify-between text-sm">
-                      <span className="text-muted-foreground">
+                      <span className="text-gray-700 dark:text-gray-300">
                         {spentPercentage.toFixed(1)}% used
                       </span>
                       <span className={remaining >= 0 ? 'text-green-600' : 'text-red-600'}>
@@ -119,7 +119,7 @@ export const BudgetTracker: React.FC = () => {
                     </div>
                     
                     {budget.notes && (
-                      <p className="text-sm text-muted-foreground italic">
+                      <p className="text-sm text-gray-700 dark:text-gray-300 italic">
                         {budget.notes}
                       </p>
                     )}

--- a/src/components/financial/FinancialLedger.tsx
+++ b/src/components/financial/FinancialLedger.tsx
@@ -96,7 +96,7 @@ export const FinancialLedger: React.FC = () => {
         <CardContent className="p-6">
           <div className="text-center">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-glee-spelman mx-auto mb-4"></div>
-            <p className="text-muted-foreground">Loading transactions...</p>
+            <p className="text-gray-700 dark:text-gray-300">Loading transactions...</p>
           </div>
         </CardContent>
       </Card>
@@ -111,7 +111,7 @@ export const FinancialLedger: React.FC = () => {
         {/* Filters */}
         <div className="flex flex-col sm:flex-row gap-4 mt-4">
           <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-700 dark:text-gray-300" />
             <Input
               placeholder="Search transactions..."
               value={searchTerm}
@@ -172,7 +172,7 @@ export const FinancialLedger: React.FC = () => {
                   <TableCell className="font-medium">
                     {transaction.description}
                     {transaction.notes && (
-                      <p className="text-sm text-muted-foreground mt-1">
+                      <p className="text-sm text-gray-700 dark:text-gray-300 mt-1">
                         {transaction.notes}
                       </p>
                     )}
@@ -237,7 +237,7 @@ export const FinancialLedger: React.FC = () => {
           </Table>
           
           {filteredTransactions.length === 0 && (
-            <div className="text-center py-8 text-muted-foreground">
+            <div className="text-center py-8 text-gray-700 dark:text-gray-300">
               No transactions found matching your filters.
             </div>
           )}

--- a/src/components/financial/FinancialSummary.tsx
+++ b/src/components/financial/FinancialSummary.tsx
@@ -84,19 +84,19 @@ export const FinancialSummary: React.FC = () => {
               <div className="text-2xl font-bold text-green-600">
                 {formatCurrency(monthlyIncome)}
               </div>
-              <p className="text-sm text-muted-foreground">Monthly Income</p>
+              <p className="text-sm text-gray-700 dark:text-gray-300">Monthly Income</p>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-red-600">
                 {formatCurrency(monthlyExpenses)}
               </div>
-              <p className="text-sm text-muted-foreground">Monthly Expenses</p>
+              <p className="text-sm text-gray-700 dark:text-gray-300">Monthly Expenses</p>
             </div>
             <div className="text-center">
               <div className={`text-2xl font-bold ${(monthlyIncome - monthlyExpenses) >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                 {formatCurrency(monthlyIncome - monthlyExpenses)}
               </div>
-              <p className="text-sm text-muted-foreground">Monthly Net</p>
+              <p className="text-sm text-gray-700 dark:text-gray-300">Monthly Net</p>
             </div>
           </div>
         </CardContent>
@@ -115,19 +115,19 @@ export const FinancialSummary: React.FC = () => {
               <div className="text-2xl font-bold text-green-600">
                 {formatCurrency(yearlyIncome)}
               </div>
-              <p className="text-sm text-muted-foreground">Yearly Income</p>
+              <p className="text-sm text-gray-700 dark:text-gray-300">Yearly Income</p>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-red-600">
                 {formatCurrency(yearlyExpenses)}
               </div>
-              <p className="text-sm text-muted-foreground">Yearly Expenses</p>
+              <p className="text-sm text-gray-700 dark:text-gray-300">Yearly Expenses</p>
             </div>
             <div className="text-center">
               <div className={`text-2xl font-bold ${(yearlyIncome - yearlyExpenses) >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                 {formatCurrency(yearlyIncome - yearlyExpenses)}
               </div>
-              <p className="text-sm text-muted-foreground">Yearly Net</p>
+              <p className="text-sm text-gray-700 dark:text-gray-300">Yearly Net</p>
             </div>
           </div>
         </CardContent>
@@ -148,7 +148,7 @@ export const FinancialSummary: React.FC = () => {
                   <Badge variant="outline">
                     {category.charAt(0).toUpperCase() + category.slice(1)}
                   </Badge>
-                  <div className="text-sm text-muted-foreground">
+                  <div className="text-sm text-gray-700 dark:text-gray-300">
                     Income: {formatCurrency(data.income)} | 
                     Expenses: {formatCurrency(data.expense)}
                   </div>
@@ -160,7 +160,7 @@ export const FinancialSummary: React.FC = () => {
             ))}
             
             {Object.keys(categoryBreakdown).length === 0 && (
-              <div className="text-center py-8 text-muted-foreground">
+              <div className="text-center py-8 text-gray-700 dark:text-gray-300">
                 No financial data available for category breakdown.
               </div>
             )}

--- a/src/pages/AdminFinancesPage.tsx
+++ b/src/pages/AdminFinancesPage.tsx
@@ -79,9 +79,9 @@ export default function AdminFinancesPage() {
     return (
       <Card>
         <CardContent className="text-center py-8">
-          <DollarSign className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+          <DollarSign className="h-12 w-12 text-gray-700 dark:text-gray-300 mx-auto mb-4" />
           <h3 className="font-semibold mb-2">Access Restricted</h3>
-          <p className="text-muted-foreground">
+          <p className="text-gray-700 dark:text-gray-300">
             You don't have permission to view financial information.
           </p>
         </CardContent>
@@ -94,7 +94,7 @@ export default function AdminFinancesPage() {
       <div className="flex justify-between items-center">
         <div>
           <h1 className="text-3xl font-bold">Financial Management</h1>
-          <p className="text-muted-foreground">
+          <p className="text-gray-700 dark:text-gray-300">
             Track dues, expenses, and revenue for the Glee Club
           </p>
         </div>
@@ -129,11 +129,11 @@ export default function AdminFinancesPage() {
             <Card>
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">Total Revenue</CardTitle>
-                <DollarSign className="h-4 w-4 text-muted-foreground" />
+                <DollarSign className="h-4 w-4 text-gray-700 dark:text-gray-300" />
               </CardHeader>
               <CardContent>
                 <div className="text-2xl font-bold">${financialData.totalRevenue.toLocaleString()}</div>
-                <p className="text-xs text-muted-foreground">
+                <p className="text-xs text-gray-700 dark:text-gray-300">
                   +12% from last semester
                 </p>
               </CardContent>
@@ -142,11 +142,11 @@ export default function AdminFinancesPage() {
             <Card>
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">Net Income</CardTitle>
-                <TrendingUp className="h-4 w-4 text-muted-foreground" />
+                <TrendingUp className="h-4 w-4 text-gray-700 dark:text-gray-300" />
               </CardHeader>
               <CardContent>
                 <div className="text-2xl font-bold">${financialData.netIncome.toLocaleString()}</div>
-                <p className="text-xs text-muted-foreground">
+                <p className="text-xs text-gray-700 dark:text-gray-300">
                   Revenue minus expenses
                 </p>
               </CardContent>
@@ -155,11 +155,11 @@ export default function AdminFinancesPage() {
             <Card>
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">Dues Collected</CardTitle>
-                <Users className="h-4 w-4 text-muted-foreground" />
+                <Users className="h-4 w-4 text-gray-700 dark:text-gray-300" />
               </CardHeader>
               <CardContent>
                 <div className="text-2xl font-bold">${financialData.duesCollected.toLocaleString()}</div>
-                <p className="text-xs text-muted-foreground">
+                <p className="text-xs text-gray-700 dark:text-gray-300">
                   {financialData.membersPaid} of {financialData.totalMembers} members
                 </p>
               </CardContent>
@@ -168,11 +168,11 @@ export default function AdminFinancesPage() {
             <Card>
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">Outstanding Dues</CardTitle>
-                <Calendar className="h-4 w-4 text-muted-foreground" />
+                <Calendar className="h-4 w-4 text-gray-700 dark:text-gray-300" />
               </CardHeader>
               <CardContent>
                 <div className="text-2xl font-bold">${financialData.outstandingDues.toLocaleString()}</div>
-                <p className="text-xs text-muted-foreground">
+                <p className="text-xs text-gray-700 dark:text-gray-300">
                   {financialData.totalMembers - financialData.membersPaid} members pending
                 </p>
               </CardContent>
@@ -192,21 +192,21 @@ export default function AdminFinancesPage() {
                 <div className="flex items-center justify-between border-b pb-2">
                   <div>
                     <p className="font-medium">Dues Payment - Jane Smith</p>
-                    <p className="text-sm text-muted-foreground">Dec 1, 2023</p>
+                    <p className="text-sm text-gray-700 dark:text-gray-300">Dec 1, 2023</p>
                   </div>
                   <Badge variant="default">+$300</Badge>
                 </div>
                 <div className="flex items-center justify-between border-b pb-2">
                   <div>
                     <p className="font-medium">Concert Hall Rental</p>
-                    <p className="text-sm text-muted-foreground">Nov 28, 2023</p>
+                    <p className="text-sm text-gray-700 dark:text-gray-300">Nov 28, 2023</p>
                   </div>
                   <Badge variant="destructive">-$1,200</Badge>
                 </div>
                 <div className="flex items-center justify-between">
                   <div>
                     <p className="font-medium">Uniform Purchase</p>
-                    <p className="text-sm text-muted-foreground">Nov 25, 2023</p>
+                    <p className="text-sm text-gray-700 dark:text-gray-300">Nov 25, 2023</p>
                   </div>
                   <Badge variant="destructive">-$450</Badge>
                 </div>
@@ -217,9 +217,9 @@ export default function AdminFinancesPage() {
       ) : (
         <Card>
           <CardContent className="text-center py-8">
-            <DollarSign className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+            <DollarSign className="h-12 w-12 text-gray-700 dark:text-gray-300 mx-auto mb-4" />
             <h3 className="font-semibold mb-2">No Financial Data</h3>
-            <p className="text-muted-foreground">
+            <p className="text-gray-700 dark:text-gray-300">
               Financial data could not be loaded at this time.
             </p>
           </CardContent>


### PR DESCRIPTION
## Summary
- darken loading and empty state text in financial ledger
- darken summary labels and category breakdown text
- darken budget tracker text
- darken informational text on AdminFinancesPage

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68542955b2248321a56b6ecda5272876