### PR TITLE
Update store links and add Square store messaging

### DIFF
--- a/src/components/landing/HomePageContent.tsx
+++ b/src/components/landing/HomePageContent.tsx
@@ -420,7 +420,7 @@ export function HomePageContent({
               Glee Store
             </h2>
             <p className="text-base md:text-lg text-gray-600 dark:text-gray-400 max-w-4xl mx-auto font-light leading-relaxed">
-              Show your support with official Spelman Glee Club merchandise
+              Shop our brand-new Square-powered store for official Spelman Glee Club gear
             </p>
           </div>
           <StoreSection products={storeProducts} />

--- a/src/components/landing/sections/StoreSection.tsx
+++ b/src/components/landing/sections/StoreSection.tsx
@@ -41,7 +41,7 @@ export function StoreSection({ products }: StoreSectionProps) {
             Show Your Glee Spirit
           </h2>
           <p className="glee-text-body max-w-2xl mx-auto">
-            Support the Spelman College Glee Club with our exclusive merchandise collection
+            Explore our new Square-powered shop and show your Glee spirit with exclusive merchandise
           </p>
         </div>
 
@@ -122,7 +122,7 @@ export function StoreSection({ products }: StoreSectionProps) {
             className="bg-gradient-to-r from-purple-500 to-blue-600 hover:from-purple-600 hover:to-blue-700 text-white px-8 py-4 text-lg font-medium shadow-lg hover:shadow-xl transition-all duration-300"
             asChild
           >
-            <Link to="/merchandise">
+            <Link to="/store">
               Shop All Products
               <ArrowRight className="h-5 w-5 ml-2" />
             </Link>

--- a/src/pages/PublicEventsPage.tsx
+++ b/src/pages/PublicEventsPage.tsx
@@ -133,14 +133,14 @@ export default function PublicEventsPage() {
                 className="h-auto p-4 justify-start text-left hover:bg-glee-spelman/5 hover:border-glee-spelman/50 dark:hover:bg-blue-400/10 dark:hover:border-blue-400/50 dark:border-border"
                 asChild
               >
-                <Link to="/merchandise" className="block">
+                <Link to="/store" className="block">
                   <div>
                     <div className="flex items-center mb-1">
                       <ShoppingBag className="h-4 w-4 mr-2 text-glee-spelman dark:text-blue-400" />
-                      <span className="font-medium dark:text-foreground">Merchandise Store</span>
+                      <span className="font-medium dark:text-foreground">Glee Store</span>
                     </div>
                     <p className="text-xs text-muted-foreground dark:text-gray-400">
-                      Shop official Glee Club merchandise
+                      Discover our new Square-powered store
                     </p>
                   </div>
                 </Link>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -105,6 +105,10 @@ const router = createBrowserRouter([
         element: <StorePage />,
       },
       {
+        path: "merchandise",
+        element: <StorePage />,
+      },
+      {
         path: "auto-generator",
         element: <AutoProductGeneratorPage />,
       },


### PR DESCRIPTION
## Summary
- add `/merchandise` route alias for the store
- update landing page text to mention new Square‑powered store
- fix store links on landing and events pages

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68543f565b9083218dba38b4cbd002da