### PR TITLE
Fix SoundCloud OAuth access

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -24,6 +24,12 @@ pop3_port = 54326
 [functions.soundcloud-api]
 verify_jwt = false
 
+[functions.soundcloud-oauth]
+verify_jwt = false
+
+[functions.soundcloud-callback]
+verify_jwt = false
+
 [auth]
 enabled = true
 site_url = "http://localhost:3000"


### PR DESCRIPTION
## Summary
- allow unauthenticated access to `soundcloud-oauth` and `soundcloud-callback` functions

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint module)*

------
https://chatgpt.com/codex/tasks/task_e_6854423b1f1083219a36fd9fdc3624fb