### PR TITLE
Fix formatting for responsive OAuth pages

### DIFF
--- a/public/soundcloud-callback.html
+++ b/public/soundcloud-callback.html
@@ -22,7 +22,7 @@
             padding: 40px;
             border-radius: 12px;
             box-shadow: 0 4px 20px rgba(0,0,0,0.15);
-            max-width: 400px;
+            max-width: min(400px, 90vw);
             width: 100%;
             text-align: center;
         }

--- a/supabase/functions/soundcloud-callback/index.ts
+++ b/supabase/functions/soundcloud-callback/index.ts
@@ -206,7 +206,7 @@ function generateErrorPage(title: string, message: string): string {
             padding: 40px;
             border-radius: 12px;
             box-shadow: 0 4px 20px rgba(0,0,0,0.15);
-            max-width: 500px;
+            max-width: min(500px, 90vw);
             width: 100%;
             text-align: center;
         }
@@ -273,7 +273,7 @@ function generateSuccessPage(tokenData: any, userData: any, origin: string): str
             padding: 40px;
             border-radius: 12px;
             box-shadow: 0 4px 20px rgba(0,0,0,0.15);
-            max-width: 500px;
+            max-width: min(500px, 90vw);
             width: 100%;
             text-align: center;
         }


### PR DESCRIPTION
## Summary
- ensure SoundCloud callback page scales to small screens
- make success/error templates from OAuth callback responsive

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e1df135c832195c2012ad74dfec1