### PR TITLE
Fix duplicate header

### DIFF
--- a/src/components/landing/PublicPageWrapper.tsx
+++ b/src/components/landing/PublicPageWrapper.tsx
@@ -1,6 +1,5 @@
 
 import React from "react";
-import { UnifiedPublicHeader } from "./UnifiedPublicHeader";
 import { OptimizedNewsTicker } from "./news/OptimizedNewsTicker";
 import { Footer } from "./Footer";
 
@@ -18,7 +17,6 @@ export function PublicPageWrapper({
   return (
     <div className={`min-h-screen bg-background ${className}`}>
       {showTopSlider && <OptimizedNewsTicker autoHide={false} />}
-      <UnifiedPublicHeader />
       <main className="flex-1">
         {children}
       </main>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,5 @@
 
 import React, { useEffect, useState } from "react";
-import { UnifiedPublicHeader } from "@/components/landing/UnifiedPublicHeader";
 import { Footer } from "@/components/landing/Footer";
 import { HomePageContent } from "@/components/landing/HomePageContent";
 import { HeroSlider } from "@/components/landing/HeroSlider";
@@ -48,9 +47,6 @@ export default function HomePage() {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header - will be sticky on its own */}
-      <UnifiedPublicHeader />
-      
       {/* Main content */}
       <main className="relative">
         <HeroSlider />


### PR DESCRIPTION
## Summary
- remove UnifiedPublicHeader from `PublicPageWrapper`
- clean up HomePage to rely on persistent header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571c0172fc8321ba229319a3a6c20c