### PR TITLE
Make containers full width

### DIFF
--- a/src/tailwind.config.ts
+++ b/src/tailwind.config.ts
@@ -10,14 +10,18 @@ module.exports = {
   ],
   theme: {
     container: {
-      center: true,
+      center: false,
       padding: {
         DEFAULT: "0.5rem",
         sm: "1rem",
         lg: "2rem",
       },
       screens: {
-        "2xl": "1400px",
+        sm: "100%",
+        md: "100%",
+        lg: "100%",
+        xl: "100%",
+        "2xl": "100%",
       },
     },
     extend: {

--- a/supabase/functions/soundcloud-callback/index.ts
+++ b/supabase/functions/soundcloud-callback/index.ts
@@ -206,7 +206,7 @@ function generateErrorPage(title: string, message: string): string {
             padding: 40px;
             border-radius: 12px;
             box-shadow: 0 4px 20px rgba(0,0,0,0.15);
-            max-width: min(500px, 90vw);
+            max-width: 100%;
             width: 100%;
             text-align: center;
         }
@@ -273,7 +273,7 @@ function generateSuccessPage(tokenData: any, userData: any, origin: string): str
             padding: 40px;
             border-radius: 12px;
             box-shadow: 0 4px 20px rgba(0,0,0,0.15);
-            max-width: min(500px, 90vw);
+            max-width: 100%;
             width: 100%;
             text-align: center;
         }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,14 +10,18 @@ module.exports = {
   ],
   theme: {
     container: {
-      center: true,
+      center: false,
       padding: {
         DEFAULT: "0.5rem",
         sm: "1rem",
         lg: "2rem",
       },
       screens: {
-        "2xl": "1400px",
+        sm: "100%",
+        md: "100%",
+        lg: "100%",
+        xl: "100%",
+        "2xl": "100%",
       },
     },
     extend: {


### PR DESCRIPTION
## Summary
- remove fixed widths from container classes in soundcloud callback
- adjust Tailwind container config so all `container` utilities span the full width

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint module missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857e7b753408321a8ffe9d224d9f6b4